### PR TITLE
Ignore vs code java plugin's project config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,10 @@ src/test/data/sandbox/
 
 # MacOS custom attributes files created by Finder
 .DS_Store
+
+# VSCode Java plugin generated files
+.classpath
+.project
+.settings
+bin
+


### PR DESCRIPTION
This PR adds vs code java plugin's generated files and directories into `.gitignore`