### PR TITLE
Implement CorrectionEngine interfaces

### DIFF
--- a/src/main/java/com/notably/logic/correction/CorrectionEngine.java
+++ b/src/main/java/com/notably/logic/correction/CorrectionEngine.java
@@ -1,0 +1,11 @@
+package com.notably.logic.correction;
+
+import java.util.List;
+
+/**
+ * Represents the correction engine instance.
+ * This is the class to with when doing string corrections.
+ */
+interface CorrectionEngine {
+    CorrectionResult correct(String actual, List<String> possibilities);
+}

--- a/src/main/java/com/notably/logic/correction/CorrectionResult.java
+++ b/src/main/java/com/notably/logic/correction/CorrectionResult.java
@@ -1,0 +1,11 @@
+package com.notably.logic.correction;
+
+import java.util.Optional;
+
+/**
+ * Represents the result of a correction.
+ */
+interface CorrectionResult {
+    CorrectionStatus getCorrectionStatus();
+    Optional<String> getCorrectedItem();
+}

--- a/src/main/java/com/notably/logic/correction/CorrectionStatus.java
+++ b/src/main/java/com/notably/logic/correction/CorrectionStatus.java
@@ -1,0 +1,10 @@
+package com.notably.logic.correction;
+
+/**
+ * Represents the status of a correction.
+ */
+enum CorrectionStatus {
+    UNCHANGED,
+    CORRECTED,
+    FAILED,
+}


### PR DESCRIPTION
Closes #68 

This PR implements the interfaces useful for the implementation of the `CorrectionEngine` logic.
As discussed in #9, I'm implementing 3 interfaces/enums: `CorrectionEngine`, `CorrectionResult`, and `CorrectionStatus`.

@johannagwan @firzanarmani @ljiazh3ng please help me check this out!