### PR TITLE
Remove coverage and coveralls scripts from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: java
 jdk: openjdk11
 
 script: >-
-    ./config/travis/run-checks.sh &&
-    ./gradlew clean checkstyleMain checkstyleTest test coverage coveralls asciidoctor
+  ./config/travis/run-checks.sh &&
+  ./gradlew clean checkstyleMain checkstyleTest test asciidoctor
 
 deploy:
   skip_cleanup: true


### PR DESCRIPTION
Missed out this call in the script in travis config file which caused an error when Travis runs a build.

Previously overlooked while removing unused CI configs in #71 