### PR TITLE
Revamp CorrectionEngine + CorrectionResult interfaces

### DIFF
--- a/src/main/java/com/notably/logic/correction/CorrectionEngine.java
+++ b/src/main/java/com/notably/logic/correction/CorrectionEngine.java
@@ -5,5 +5,11 @@ package com.notably.logic.correction;
  * This is the class to interact with when doing corrections.
  */
 interface CorrectionEngine<T> {
-    CorrectionResult<T> correct(T actual);
+    /**
+     * Corrects a given item.
+     *
+     * @param uncorrected Uncorrected input
+     * @return Result of the correction
+     */
+    CorrectionResult<T> correct(T uncorrected);
 }

--- a/src/main/java/com/notably/logic/correction/CorrectionEngine.java
+++ b/src/main/java/com/notably/logic/correction/CorrectionEngine.java
@@ -1,11 +1,9 @@
 package com.notably.logic.correction;
 
-import java.util.List;
-
 /**
- * Represents the correction engine instance.
- * This is the class to with when doing string corrections.
+ * Represents a correction engine.
+ * This is the class to interact with when doing corrections.
  */
-interface CorrectionEngine {
-    CorrectionResult correct(String actual, List<String> possibilities);
+interface CorrectionEngine<T> {
+    CorrectionResult<T> correct(T actual);
 }

--- a/src/main/java/com/notably/logic/correction/CorrectionResult.java
+++ b/src/main/java/com/notably/logic/correction/CorrectionResult.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 /**
  * Represents the result of a correction.
  */
-interface CorrectionResult {
+interface CorrectionResult<T> {
     CorrectionStatus getCorrectionStatus();
-    Optional<String> getCorrectedItem();
+    Optional<T> getCorrectedItem();
 }

--- a/src/main/java/com/notably/logic/correction/CorrectionResult.java
+++ b/src/main/java/com/notably/logic/correction/CorrectionResult.java
@@ -15,8 +15,9 @@ interface CorrectionResult<T> {
     /**
      * Gets the corrected item.
      * If correction cannot be done, {@code Optional.empty()} will be returned.
-     * 
+     *
      * @return The corrected item, or {@code Optional.empty()} if correction fails
      */
     Optional<T> getCorrectedItem();
 }
+

--- a/src/main/java/com/notably/logic/correction/CorrectionResult.java
+++ b/src/main/java/com/notably/logic/correction/CorrectionResult.java
@@ -6,6 +6,17 @@ import java.util.Optional;
  * Represents the result of a correction.
  */
 interface CorrectionResult<T> {
+    /**
+     * Gets the status of the correction.
+     *
+     * @return The status of the correction
+     */
     CorrectionStatus getCorrectionStatus();
+    /**
+     * Gets the corrected item.
+     * If correction cannot be done, {@code Optional.empty()} will be returned.
+     * 
+     * @return The corrected item, or {@code Optional.empty()} if correction fails
+     */
     Optional<T> getCorrectedItem();
 }


### PR DESCRIPTION
This PR does the following:
- [x] Revamp the `CorrectionEngine` and `CorrectionResult` interfaces (resolves #97)
- [x] Add Javadoc comments to `CorrectionEngine` and `CorrectionResult`