### PR TITLE
Make Model extend SuggestionModel

### DIFF
--- a/src/main/java/com/notably/model/Model.java
+++ b/src/main/java/com/notably/model/Model.java
@@ -4,13 +4,14 @@ import java.nio.file.Path;
 import java.util.function.Predicate;
 
 import com.notably.commons.core.GuiSettings;
+import com.notably.model.suggestion.SuggestionModel;
 
 import javafx.collections.ObservableList;
 
 /**
  * The API of the Model component.
  */
-public interface Model {
+public interface Model extends SuggestionModel {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Object> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
 

--- a/src/main/java/com/notably/model/Model.java
+++ b/src/main/java/com/notably/model/Model.java
@@ -4,9 +4,8 @@ import java.nio.file.Path;
 import java.util.function.Predicate;
 
 import com.notably.commons.core.GuiSettings;
-import com.notably.model.suggestion.SuggestionModel;
-
 import com.notably.model.commandinput.CommandInputModel;
+import com.notably.model.suggestion.SuggestionModel;
 
 import javafx.collections.ObservableList;
 

--- a/src/main/java/com/notably/model/ModelManager.java
+++ b/src/main/java/com/notably/model/ModelManager.java
@@ -167,8 +167,8 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public Property<Optional<String>> commandTextProperty() {
-        return suggestionModel.commandTextProperty();
+    public Property<Optional<String>> getCommandTextProperty() {
+        return suggestionModel.getCommandTextProperty();
     }
 
     @Override

--- a/src/main/java/com/notably/model/ModelManager.java
+++ b/src/main/java/com/notably/model/ModelManager.java
@@ -4,24 +4,31 @@ import static com.notably.commons.util.CollectionUtil.requireAllNonNull;
 import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import com.notably.commons.core.GuiSettings;
 import com.notably.commons.core.LogsCenter;
+import com.notably.model.suggestion.SuggestionItem;
+import com.notably.model.suggestion.SuggestionModel;
 
+import javafx.beans.property.Property;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 
+// TODO: to update according to our Model classes.
 /**
  * Represents the in-memory model of the address book data.
  */
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
-    private final AddressBook addressBook;
-    private final UserPrefs userPrefs;
-    private final FilteredList<Object> filteredPersons;
+    private AddressBook addressBook;
+    private UserPrefs userPrefs;
+    private FilteredList<Object> filteredPersons;
+    private SuggestionModel suggestionModel;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -39,6 +46,11 @@ public class ModelManager implements Model {
 
     public ModelManager() {
         this(new AddressBook(), new UserPrefs());
+    }
+
+    // TODO: to update constructor according to our Model classes.
+    public ModelManager(SuggestionModel suggestionModel) {
+        this.suggestionModel = suggestionModel;
     }
 
     //=========== UserPrefs ==================================================================================
@@ -143,4 +155,39 @@ public class ModelManager implements Model {
                 && filteredPersons.equals(other.filteredPersons);
     }
 
+    //=========== Suggestion Model =============================================================
+    @Override
+    public ObservableList<SuggestionItem> getSuggestions() {
+        return suggestionModel.getSuggestions();
+    }
+
+    @Override
+    public void setSuggestions(List<SuggestionItem> suggestions) {
+        suggestionModel.setSuggestions(suggestions);
+    }
+
+    @Override
+    public Property<Optional<String>> commandTextProperty() {
+        return suggestionModel.commandTextProperty();
+    }
+
+    @Override
+    public void setCommandInputText(String commandInputText) {
+        suggestionModel.setCommandInputText(commandInputText);
+    }
+
+    @Override
+    public String getCommandInputText() {
+        return suggestionModel.getCommandInputText();
+    }
+
+    @Override
+    public void clearCommandInputText() {
+        suggestionModel.clearCommandInputText();
+    }
+
+    @Override
+    public void clearSuggestions() {
+        suggestionModel.clearSuggestions();
+    }
 }

--- a/src/main/java/com/notably/model/ModelManager.java
+++ b/src/main/java/com/notably/model/ModelManager.java
@@ -12,12 +12,12 @@ import java.util.logging.Logger;
 import com.notably.commons.core.GuiSettings;
 import com.notably.commons.core.LogsCenter;
 
+import com.notably.model.commandinput.CommandInputModel;
+
 import com.notably.model.suggestion.SuggestionItem;
 import com.notably.model.suggestion.SuggestionModel;
 
 import javafx.beans.property.Property;
-
-import com.notably.model.commandinput.CommandInputModel;
 
 import javafx.beans.property.StringProperty;
 
@@ -31,11 +31,12 @@ import javafx.collections.transformation.FilteredList;
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
-    private final AddressBook addressBook;
-    private final UserPrefs userPrefs;
-    private final FilteredList<Object> filteredPersons;
-    private final SuggestionModel suggestionModel;
-    private final CommandInputModel commandInputModel;
+    private AddressBook addressBook;
+    private UserPrefs userPrefs;
+    private FilteredList<Object> filteredPersons;
+    // TODO: set the model variables to final after removing the AB3 attributes.
+    private SuggestionModel suggestionModel;
+    private CommandInputModel commandInputModel;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -175,28 +176,24 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public Property<Optional<String>> getCommandTextProperty() {
-        return suggestionModel.getCommandTextProperty();
+    public Property<Optional<String>> responseTextProperty() {
+        return suggestionModel.responseTextProperty();
     }
 
     @Override
-    public void setCommandInputText(String commandInputText) {
-        suggestionModel.setCommandInputText(commandInputText);
+    public void setResponseText(String responseText) {
+        suggestionModel.setResponseText(responseText);
     }
 
     @Override
-    public String getCommandInputText() {
-        return suggestionModel.getCommandInputText();
-    }
-
-    @Override
-    public void clearCommandInputText() {
-        suggestionModel.clearCommandInputText();
+    public void clearResponseText() {
+        suggestionModel.clearResponseText();
     }
 
     @Override
     public void clearSuggestions() {
         suggestionModel.clearSuggestions();
+    }
 
     //========= CommandInputModel==================================================================
 


### PR DESCRIPTION
Closes #107 

Changes include:
- Make Model extend SuggestionModel
- Make ModelManager implement methods from SuggestionModel

This PR has not dealt with connecting the updated `ModelManager` with `MainApp` class, i.e. the `initModelManager` method in `MainApp.java` will still return `new ModelManager(initialData, userPrefs);` and not `new ModelManager(suggestionModel)`.