### PR TITLE
Add suggestion commands

### DIFF
--- a/src/main/java/com/notably/logic/suggestion/commands/ErrorSuggestionCommand.java
+++ b/src/main/java/com/notably/logic/suggestion/commands/ErrorSuggestionCommand.java
@@ -1,0 +1,10 @@
+package com.notably.logic.suggestion.commands;
+
+import com.notably.model.Model;
+
+public class ErrorSuggestionCommand implements SuggestionCommand {
+    @Override
+    public void execute(Model model) {
+
+    }
+}

--- a/src/main/java/com/notably/logic/suggestion/commands/ErrorSuggestionCommand.java
+++ b/src/main/java/com/notably/logic/suggestion/commands/ErrorSuggestionCommand.java
@@ -2,6 +2,9 @@ package com.notably.logic.suggestion.commands;
 
 import com.notably.model.Model;
 
+/**
+ * Represents an error command when the user input do not match any of the available commands or blocks.
+ */
 public class ErrorSuggestionCommand implements SuggestionCommand {
     @Override
     public void execute(Model model) {

--- a/src/main/java/com/notably/logic/suggestion/commands/OpenSuggestionCommand.java
+++ b/src/main/java/com/notably/logic/suggestion/commands/OpenSuggestionCommand.java
@@ -1,0 +1,46 @@
+package com.notably.logic.suggestion.commands;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.notably.commons.core.path.Path;
+import com.notably.logic.suggestion.stubs.SuggestionListStub;
+import com.notably.model.Model;
+import com.notably.model.suggestion.SuggestionItem;
+import com.notably.model.suggestion.SuggestionItemImpl;
+
+/**
+ * Represents a suggestion command object to open a note.
+ */
+public class OpenSuggestionCommand implements SuggestionCommand {
+    private Path path;
+
+    public OpenSuggestionCommand(Path path) {
+        this.path = path;
+    }
+
+    @Override
+    public void execute(Model model) {
+        List<String> suggestionList = getSuggestionList(path);
+        List<SuggestionItem> suggestions = new ArrayList<>();
+
+        for (String suggestion : suggestionList) {
+            Runnable action = () -> {
+                model.setCommandInputText("open " + suggestion);
+            };
+            SuggestionItem suggestionItem = new SuggestionItemImpl(suggestion, action);
+            suggestions.add(suggestionItem);
+        }
+
+        model.setSuggestions(suggestions);
+    }
+
+    private List<String> getSuggestionList(Path path) {
+        List<String> paths = path.getComponents();
+
+        // TODO: traverse tree. For now will just use stubs.
+        SuggestionListStub suggestionListStub = new SuggestionListStub();
+        List<String> suggestionList = suggestionListStub.getSuggestionList();
+        return suggestionList;
+    }
+}

--- a/src/main/java/com/notably/logic/suggestion/commands/OpenSuggestionCommand.java
+++ b/src/main/java/com/notably/logic/suggestion/commands/OpenSuggestionCommand.java
@@ -25,10 +25,11 @@ public class OpenSuggestionCommand implements SuggestionCommand {
         List<SuggestionItem> suggestions = new ArrayList<>();
 
         for (String suggestion : suggestionList) {
+            String displayText = "open " + suggestion;
             Runnable action = () -> {
-                model.setCommandInputText("open " + suggestion);
+                model.setCommandInputText(displayText);
             };
-            SuggestionItem suggestionItem = new SuggestionItemImpl(suggestion, action);
+            SuggestionItem suggestionItem = new SuggestionItemImpl(displayText, action);
             suggestions.add(suggestionItem);
         }
 

--- a/src/main/java/com/notably/logic/suggestion/commands/SearchSuggestionCommand.java
+++ b/src/main/java/com/notably/logic/suggestion/commands/SearchSuggestionCommand.java
@@ -1,0 +1,46 @@
+package com.notably.logic.suggestion.commands;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.notably.commons.core.path.Path;
+import com.notably.logic.suggestion.stubs.SuggestionListStub;
+import com.notably.model.Model;
+import com.notably.model.suggestion.SuggestionItem;
+import com.notably.model.suggestion.SuggestionItemImpl;
+
+/**
+ * Represents a suggestion command object to search a note.
+ */
+public class SearchSuggestionCommand implements SuggestionCommand {
+    private Path path;
+
+    public SearchSuggestionCommand(Path path) {
+        this.path = path;
+    }
+
+    @Override
+    public void execute(Model model) {
+        List<String> suggestionList = getSuggestionList(path);
+        List<SuggestionItem> suggestions = new ArrayList<>();
+
+        for (String suggestion : suggestionList) {
+            Runnable action = () -> {
+                model.setCommandInputText("search " + suggestion);
+            };
+            SuggestionItem suggestionItem = new SuggestionItemImpl(suggestion, action);
+            suggestions.add(suggestionItem);
+        }
+
+        model.setSuggestions(suggestions);
+    }
+
+    private List<String> getSuggestionList(Path path) {
+        List<String> paths = path.getComponents();
+
+        // TODO: traverse tree. For now will just use stubs.
+        SuggestionListStub suggestionListStub = new SuggestionListStub();
+        List<String> suggestionList = suggestionListStub.getSuggestionList();
+        return suggestionList;
+    }
+}

--- a/src/main/java/com/notably/logic/suggestion/commands/SearchSuggestionCommand.java
+++ b/src/main/java/com/notably/logic/suggestion/commands/SearchSuggestionCommand.java
@@ -25,10 +25,11 @@ public class SearchSuggestionCommand implements SuggestionCommand {
         List<SuggestionItem> suggestions = new ArrayList<>();
 
         for (String suggestion : suggestionList) {
+            String displayText = "search " + suggestion;
             Runnable action = () -> {
-                model.setCommandInputText("search " + suggestion);
+                model.setCommandInputText(displayText);
             };
-            SuggestionItem suggestionItem = new SuggestionItemImpl(suggestion, action);
+            SuggestionItem suggestionItem = new SuggestionItemImpl(displayText, action);
             suggestions.add(suggestionItem);
         }
 

--- a/src/main/java/com/notably/logic/suggestion/commands/SuggestionCommand.java
+++ b/src/main/java/com/notably/logic/suggestion/commands/SuggestionCommand.java
@@ -1,4 +1,4 @@
-package com.notably.logic.suggestion;
+package com.notably.logic.suggestion.commands;
 
 import com.notably.model.Model;
 

--- a/src/main/java/com/notably/logic/suggestion/stubs/SuggestionListStub.java
+++ b/src/main/java/com/notably/logic/suggestion/stubs/SuggestionListStub.java
@@ -1,0 +1,24 @@
+package com.notably.logic.suggestion.stubs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a hardcoded suggestion list object.
+ */
+public class SuggestionListStub {
+    public SuggestionListStub() {
+
+    }
+
+    public List<String> getSuggestionList() {
+        List<String> suggestionListStub = new ArrayList<>();
+        suggestionListStub.add("/y2s2/cs2103t");
+        suggestionListStub.add("/y2s2/cs2103t/IP");
+        suggestionListStub.add("/y2s2/cs2103t/TP");
+        suggestionListStub.add("/y2s2/cs2103t/Quiz");
+        suggestionListStub.add("/y2s2/cs2101");
+
+        return suggestionListStub;
+    }
+}


### PR DESCRIPTION
Closes #113 
Currently added:
- OpenSuggestionCommand
- SearchSuggestionCommand
- ErrorSuggestionCommand
- SuggestionListStub (just for the sake of testing, will be deleted in the future)

When a particular suggestion is chosen, the `commandInputText` in the model will be updated.
Currently, I just used a hard-coded list for the data.