### PR TITLE
Make Model extend CommandInputModel

### DIFF
--- a/src/main/java/com/notably/model/Model.java
+++ b/src/main/java/com/notably/model/Model.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 import com.notably.commons.core.GuiSettings;
 
 import com.notably.model.commandinput.CommandInputModel;
+
 import javafx.collections.ObservableList;
 
 /**

--- a/src/main/java/com/notably/model/Model.java
+++ b/src/main/java/com/notably/model/Model.java
@@ -5,12 +5,13 @@ import java.util.function.Predicate;
 
 import com.notably.commons.core.GuiSettings;
 
+import com.notably.model.commandinput.CommandInputModel;
 import javafx.collections.ObservableList;
 
 /**
  * The API of the Model component.
  */
-public interface Model {
+public interface Model extends CommandInputModel {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Object> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
 

--- a/src/main/java/com/notably/model/ModelManager.java
+++ b/src/main/java/com/notably/model/ModelManager.java
@@ -10,6 +10,9 @@ import java.util.logging.Logger;
 import com.notably.commons.core.GuiSettings;
 import com.notably.commons.core.LogsCenter;
 
+import com.notably.logic.commands.Command;
+import com.notably.model.commandinput.CommandInputModel;
+import javafx.beans.property.StringProperty;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 
@@ -19,9 +22,11 @@ import javafx.collections.transformation.FilteredList;
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
-    private final AddressBook addressBook;
-    private final UserPrefs userPrefs;
-    private final FilteredList<Object> filteredPersons;
+    private AddressBook addressBook;
+    private UserPrefs userPrefs;
+    private FilteredList<Object> filteredPersons;
+    private CommandInputModel commandInputModel;
+
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -39,6 +44,11 @@ public class ModelManager implements Model {
 
     public ModelManager() {
         this(new AddressBook(), new UserPrefs());
+    }
+
+    // TODO: to update constructor according to our Model classes.
+    public ModelManager(CommandInputModel commandInputModel) {
+        this.commandInputModel = commandInputModel;
     }
 
     //=========== UserPrefs ==================================================================================
@@ -143,4 +153,20 @@ public class ModelManager implements Model {
                 && filteredPersons.equals(other.filteredPersons);
     }
 
+    //========= CommandInputModel==================================================================
+
+    @Override
+    public StringProperty inputProperty() {
+        return commandInputModel.inputProperty();
+    }
+
+    @Override
+    public String getInput() {
+        return commandInputModel.getInput();
+    }
+
+    @Override
+    public void setInput(String input) {
+        commandInputModel.setInput(input);
+    }
 }

--- a/src/main/java/com/notably/model/ModelManager.java
+++ b/src/main/java/com/notably/model/ModelManager.java
@@ -9,9 +9,8 @@ import java.util.logging.Logger;
 
 import com.notably.commons.core.GuiSettings;
 import com.notably.commons.core.LogsCenter;
-
-import com.notably.logic.commands.Command;
 import com.notably.model.commandinput.CommandInputModel;
+
 import javafx.beans.property.StringProperty;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;


### PR DESCRIPTION
Closes #131.

Changes include:

- Make Model extend CommandInputModel
- Make ModelManager implement methods from CommandInputModel

This PR has not dealt with connecting the updated ModelManager with MainApp class, i.e. the initModelManager method in MainApp.java will still return new ModelManager(initialData, userPrefs); and not new ModelManager(CommandInputModel).