### PR TITLE
Implement getStringRepresentation method in Path classes

### DIFF
--- a/src/main/java/com/notably/commons/core/path/AbsolutePath.java
+++ b/src/main/java/com/notably/commons/core/path/AbsolutePath.java
@@ -55,7 +55,7 @@ public class AbsolutePath implements Path {
      * @return Absolute Path.
      * @throws InvalidPathException if String provided is not a valid absolutePath.
      */
-    public static AbsolutePath fromComponent(List<String> absoluteComponents) {
+    public static AbsolutePath fromComponents(List<String> absoluteComponents) {
         return new AbsolutePath(absoluteComponents);
     }
 

--- a/src/main/java/com/notably/commons/core/path/AbsolutePath.java
+++ b/src/main/java/com/notably/commons/core/path/AbsolutePath.java
@@ -95,12 +95,14 @@ public class AbsolutePath implements Path {
         return RelativePath.fromAbsolutePath(this, currentWorkingPath);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public List<String> getComponents() {
         return this.components;
+    }
+
+    @Override
+    public String getStringRepresentation() {
+        return "/" + String.join("/", this.components);
     }
 
     @Override
@@ -121,7 +123,7 @@ public class AbsolutePath implements Path {
 
     @Override
     public String toString() {
-        return "/" + String.join("/", this.components);
+        return getStringRepresentation();
     }
 }
 

--- a/src/main/java/com/notably/commons/core/path/Path.java
+++ b/src/main/java/com/notably/commons/core/path/Path.java
@@ -3,12 +3,22 @@ package com.notably.commons.core.path;
 import java.util.List;
 
 /**
- * TODO: Add Javadoc
+ * Represents a path to a {@link Block}.
  */
 public interface Path {
     /**
-     * TODO: Add Javadoc
+     * Gets the string components of a path.
+     * For example, a path /a/b/c have the components ["a", "b", "c"].
+     *
+     * @return Components of a path
      */
     List<String> getComponents();
+    /**
+     * Gets the string representation of a path.
+     * For example, "/a/b/c" is a string representation of a path.
+     *
+     * @return String representation of a path
+     */
+    String getStringRepresentation();
 }
 

--- a/src/main/java/com/notably/commons/core/path/RelativePath.java
+++ b/src/main/java/com/notably/commons/core/path/RelativePath.java
@@ -89,12 +89,14 @@ public class RelativePath implements Path {
         return AbsolutePath.fromRelativePath(this, currentWorkingPath);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public List<String> getComponents() {
         return this.components;
+    }
+
+    @Override
+    public String getStringRepresentation() {
+        return String.join("/", this.components);
     }
 
     @Override
@@ -137,7 +139,7 @@ public class RelativePath implements Path {
 
     @Override
     public String toString() {
-        return String.join("/", this.components);
+        return getStringRepresentation();
     }
 }
 


### PR DESCRIPTION
Closes #145 

This PR does the following:
- [x] Adds a `getStringRepresentation` method (for reason explained in #145)
- [x] Add Javadocs to `Path` interface
- [x] Rename `fromComponent` in `AbsolutePath` to `fromComponents` for consistency with `RelativePath#fromComponents`