### PR TITLE
Make InvalidPathException a RuntimeException

### DIFF
--- a/src/main/java/com/notably/commons/core/path/AbsolutePath.java
+++ b/src/main/java/com/notably/commons/core/path/AbsolutePath.java
@@ -40,9 +40,8 @@ public class AbsolutePath implements Path {
      * Creates an absolute path from a string.
      * @param absolutePathString used to create an absolutePath.
      * @return Absolute Path.
-     * @throws InvalidPathException if String provided is not a valid absolutePath.
      */
-    public static AbsolutePath fromString(String absolutePathString) throws InvalidPathException {
+    public static AbsolutePath fromString(String absolutePathString) {
         if (!isValidAbsolutePath(absolutePathString)) {
             throw new InvalidPathException(INVALID_ABSOLUTE_PATH);
         }
@@ -53,7 +52,6 @@ public class AbsolutePath implements Path {
      * Creates an absolute path from a list of components.
      * @param absoluteComponents used to create an absolutePath.
      * @return Absolute Path.
-     * @throws InvalidPathException if String provided is not a valid absolutePath.
      */
     public static AbsolutePath fromComponents(List<String> absoluteComponents) {
         return new AbsolutePath(absoluteComponents);
@@ -65,10 +63,9 @@ public class AbsolutePath implements Path {
      * @param relativePath used to convert to absolute path.
      * @param currentWorkingPath of the current working directory.
      * @return the converted AbsolutePath.
-     * @throws InvalidPathException
      */
     public static AbsolutePath fromRelativePath(RelativePath relativePath,
-            AbsolutePath currentWorkingPath) throws InvalidPathException {
+            AbsolutePath currentWorkingPath) {
         List<String> temp = new ArrayList<>(relativePath.getComponents());
         List<String> temp2 = new ArrayList<>(currentWorkingPath.getComponents());
         for (String obj : temp) {

--- a/src/main/java/com/notably/commons/core/path/RelativePath.java
+++ b/src/main/java/com/notably/commons/core/path/RelativePath.java
@@ -40,9 +40,8 @@ public class RelativePath implements Path {
      * Instantiate a RelativePath object if the string is valid.
      * @param relativePathString used to create RelativePath.
      * @return the converted RelativePath object.
-     * @throws InvalidPathException if the String is invalid (Not relative path).
      */
-    public static RelativePath fromString(String relativePathString) throws InvalidPathException {
+    public static RelativePath fromString(String relativePathString) {
         if (!isValidRelativePath(relativePathString)) {
             throw new InvalidPathException("Not a relative path");
         }
@@ -65,7 +64,6 @@ public class RelativePath implements Path {
      * @param absolutePath to convert to relative path.
      * @param currentWorkingPath of the current working directory.
      * @return the converted relative path.
-     * @throws InvalidPathException
      */
     public static RelativePath fromAbsolutePath(AbsolutePath absolutePath,
             AbsolutePath currentWorkingPath) {
@@ -85,7 +83,7 @@ public class RelativePath implements Path {
      * @param currentWorkingPath of the current working directory.
      * @return the absolute path of the relative path.
      */
-    public AbsolutePath toAbsolutePath(AbsolutePath currentWorkingPath) throws InvalidPathException {
+    public AbsolutePath toAbsolutePath(AbsolutePath currentWorkingPath) {
         return AbsolutePath.fromRelativePath(this, currentWorkingPath);
     }
 

--- a/src/main/java/com/notably/commons/core/path/exceptions/InvalidPathException.java
+++ b/src/main/java/com/notably/commons/core/path/exceptions/InvalidPathException.java
@@ -1,10 +1,12 @@
 package com.notably.commons.core.path.exceptions;
 
+import com.notably.commons.core.path.Path;
+
 /**
- * TODO: Add Javadoc
+ * {@link RuntimeException} to be thrown when an invalid representation of a path is supplied during
+ * {@link Path} creation.
  */
-public class InvalidPathException extends Exception {
-    // TODO: Add appropriate constructors
+public class InvalidPathException extends RuntimeException {
     public InvalidPathException(String message) {
         super(message);
     }

--- a/src/main/java/com/notably/logic/correction/AbsolutePathCorrectionEngine.java
+++ b/src/main/java/com/notably/logic/correction/AbsolutePathCorrectionEngine.java
@@ -8,7 +8,6 @@ import java.util.Queue;
 import java.util.stream.Collectors;
 
 import com.notably.commons.core.path.AbsolutePath;
-import com.notably.commons.core.path.exceptions.InvalidPathException;
 import com.notably.logic.correction.distance.EditDistanceCalculator;
 import com.notably.logic.correction.distance.LevenshteinDistanceCalculator;
 import com.notably.model.Model;
@@ -83,11 +82,7 @@ public class AbsolutePathCorrectionEngine implements CorrectionEngine<AbsolutePa
         List<AbsolutePath> possiblePaths = new ArrayList<>();
 
         Queue<AbsolutePath> pathQueue = new LinkedList<>();
-        try {
-            pathQueue.offer(AbsolutePath.fromString("/"));
-        } catch (InvalidPathException exception) {
-            throw new AssertionError(exception);
-        }
+        pathQueue.offer(AbsolutePath.fromString("/"));
 
         while (!pathQueue.isEmpty()) {
             AbsolutePath currentPath = pathQueue.poll();

--- a/src/test/java/com/notably/commons/core/Path/AbsolutePathTest.java
+++ b/src/test/java/com/notably/commons/core/Path/AbsolutePathTest.java
@@ -14,7 +14,7 @@ import com.notably.commons.core.path.exceptions.InvalidPathException;
 class AbsolutePathTest {
 
     @Test
-    public void fromString_validInputString_generateAbsolutePath() throws InvalidPathException {
+    public void fromString_validInputString_generateAbsolutePath() {
         final AbsolutePath testInput = AbsolutePath.fromString("/CS2103/notes");
 
         List<String> paths = new ArrayList<>();
@@ -25,7 +25,7 @@ class AbsolutePathTest {
     }
 
     @Test
-    public void fromString_validEmptyString_generateAbsolutePath() throws InvalidPathException {
+    public void fromString_validEmptyString_generateAbsolutePath() {
         final AbsolutePath testInput = AbsolutePath.fromString("/");
 
         List<String> paths = new ArrayList<>();
@@ -44,7 +44,7 @@ class AbsolutePathTest {
     }
 
     @Test
-    public void toRelativePath_validInput_correctedPath() throws InvalidPathException {
+    public void toRelativePath_validInput_correctedPath() {
         final AbsolutePath inputAbsolutePath = AbsolutePath.fromString("/CS2103/notes/hello");
         final AbsolutePath inputCurrPath = AbsolutePath.fromString("/CS2103");
 
@@ -54,7 +54,7 @@ class AbsolutePathTest {
     }
 
     @Test
-    public void fromRelativePath_validInput_convertedAbsolutePath() throws InvalidPathException {
+    public void fromRelativePath_validInput_convertedAbsolutePath() {
         final RelativePath inputRelPath = RelativePath.fromString("../../hello");
         final AbsolutePath inputCurrPath = AbsolutePath.fromString("/CS2103/filler");
 
@@ -65,7 +65,7 @@ class AbsolutePathTest {
     }
 
     @Test
-    public void fromRelativePath_invalidInput_exceptionThrown() throws InvalidPathException {
+    public void fromRelativePath_invalidInput_exceptionThrown() {
         final RelativePath inputRelPath = RelativePath.fromString("../../hello");
         final AbsolutePath inputCurrPath = AbsolutePath.fromString("/CS2103");
         assertThrows(InvalidPathException.class, () -> AbsolutePath.fromRelativePath(inputRelPath, inputCurrPath));

--- a/src/test/java/com/notably/commons/core/Path/RelativePathTest.java
+++ b/src/test/java/com/notably/commons/core/Path/RelativePathTest.java
@@ -16,7 +16,7 @@ import com.notably.commons.core.path.exceptions.InvalidPathException;
 class RelativePathTest {
 
     @Test
-    public void fromString_validInputString_generateAbsolutePath() throws InvalidPathException {
+    public void fromString_validInputString_generateAbsolutePath() {
         final RelativePath testInput = RelativePath.fromString("CS2103/notes");
         List<String> paths = new ArrayList<>();
         paths.add("CS2103");
@@ -30,7 +30,7 @@ class RelativePathTest {
     }
 
     @Test
-    public void toAbsolutePath_validInput_correctedPath() throws InvalidPathException {
+    public void toAbsolutePath_validInput_correctedPath() {
         final RelativePath inputRelativePath = RelativePath.fromString("CS2103/notes/hello");
         final AbsolutePath inputCurrPath = AbsolutePath.fromString("/CS2103");
 
@@ -40,7 +40,7 @@ class RelativePathTest {
     }
 
     @Test
-    public void toAbsolutePath_invalidInput_exceptionThrown() throws InvalidPathException {
+    public void toAbsolutePath_invalidInput_exceptionThrown() {
         final RelativePath inputRelativePath = RelativePath.fromString("../../notes/hello");
         final AbsolutePath inputCurrPath = AbsolutePath.fromString("/CS2103");
 
@@ -48,7 +48,7 @@ class RelativePathTest {
     }
 
     @Test
-    public void equals_similarPath_pathAreEqual() throws InvalidPathException {
+    public void equals_similarPath_pathAreEqual() {
         final RelativePath inputRelativePath1 = RelativePath.fromString("CS2103/../CS2103");
         final RelativePath inputRelativePath2 = RelativePath.fromString("CS2103");
 

--- a/src/test/java/com/notably/logic/correction/AbsolutePathCorrectionEngineTest.java
+++ b/src/test/java/com/notably/logic/correction/AbsolutePathCorrectionEngineTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.Test;
 
 import com.notably.commons.core.path.AbsolutePath;
-import com.notably.commons.core.path.exceptions.InvalidPathException;
 import com.notably.model.Model;
 import com.notably.model.block.BlockImpl;
 import com.notably.model.block.BlockTree;
@@ -19,15 +18,9 @@ public class AbsolutePathCorrectionEngineTest {
         @Override
         public BlockTree getBlockTree() {
             BlockTree stubTree = new BlockTreeImpl();
-
-            try {
-                stubTree.add(AbsolutePath.fromString("/"), new BlockImpl(new Title("block")));
-                stubTree.add(AbsolutePath.fromString("/"), new BlockImpl(new Title("another")));
-                stubTree.add(AbsolutePath.fromString("/another"), new BlockImpl(new Title("block")));
-            } catch (InvalidPathException exception) {
-                throw new AssertionError(exception);
-            }
-
+            stubTree.add(AbsolutePath.fromString("/"), new BlockImpl(new Title("block")));
+            stubTree.add(AbsolutePath.fromString("/"), new BlockImpl(new Title("another")));
+            stubTree.add(AbsolutePath.fromString("/another"), new BlockImpl(new Title("block")));
             return stubTree;
         }
     }
@@ -43,7 +36,7 @@ public class AbsolutePathCorrectionEngineTest {
     }
 
     @Test
-    public void correct_withinDistanceThreshold_correctionDone() throws InvalidPathException {
+    public void correct_withinDistanceThreshold_correctionDone() {
         final int distanceThreshold = 2;
         final AbsolutePathCorrectionEngine correctionEngine = new AbsolutePathCorrectionEngine(
                 modelStub, distanceThreshold);
@@ -59,7 +52,7 @@ public class AbsolutePathCorrectionEngineTest {
     }
 
     @Test
-    public void correct_exceedDistanceThreshold_correctionFailed() throws InvalidPathException {
+    public void correct_exceedDistanceThreshold_correctionFailed() {
         final int distanceThreshold = 1;
         final AbsolutePathCorrectionEngine correctionEngine = new AbsolutePathCorrectionEngine(
                 modelStub, distanceThreshold);
@@ -73,7 +66,7 @@ public class AbsolutePathCorrectionEngineTest {
     }
 
     @Test
-    public void correct_exactMatch_noCorrection() throws InvalidPathException {
+    public void correct_exactMatch_noCorrection() {
         final int distanceThreshold = 1;
         final AbsolutePathCorrectionEngine correctionEngine = new AbsolutePathCorrectionEngine(
                 modelStub, distanceThreshold);

--- a/src/test/java/com/notably/model/block/BlockTreeTest.java
+++ b/src/test/java/com/notably/model/block/BlockTreeTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.notably.commons.core.path.AbsolutePath;
-import com.notably.commons.core.path.exceptions.InvalidPathException;
 import com.notably.model.block.exceptions.CannotModifyRootException;
 import com.notably.model.block.exceptions.DuplicateBlockException;
 import com.notably.model.block.exceptions.NoSuchBlockException;
@@ -24,7 +23,7 @@ public class BlockTreeTest {
     private BlockTree blockTree = new BlockTreeImpl();
 
     @BeforeAll
-    public static void setUp() throws InvalidPathException {
+    public static void setUp() {
         toRoot = AbsolutePath.fromString("/");
         toCs2103 = AbsolutePath.fromString("/CS2103");
         toCs2103Week1 = AbsolutePath.fromString("/CS2103/Week1");
@@ -52,18 +51,18 @@ public class BlockTreeTest {
     }
 
     @Test
-    public void get_root() throws InvalidPathException {
+    public void get_root() {
         assertEquals(blockTree.get(toRoot), blockTree.getRootBlock());
     }
 
     @Test
-    public void get_pathDoesNotExist_throwsNoSuchBlockException() throws InvalidPathException {
+    public void get_pathDoesNotExist_throwsNoSuchBlockException() {
         AbsolutePath nonExistentPath = AbsolutePath.fromString("/SomeNonExistentPath");
         assertThrows(NoSuchBlockException.class, () -> blockTree.get(nonExistentPath));
     }
 
     @Test
-    public void add_block() throws InvalidPathException {
+    public void add_block() {
         Block newBlock = new BlockImpl(new Title("Week2"));
         AbsolutePath toCs2103Week2 = AbsolutePath.fromString("/CS2103/Week2");
         blockTree.add(toCs2103, newBlock);
@@ -101,7 +100,7 @@ public class BlockTreeTest {
     }
 
     @Test
-    public void set_block_editBlock() throws CannotModifyRootException, InvalidPathException {
+    public void set_block_editBlock() throws CannotModifyRootException {
         Block editedBlock = new BlockImpl(new Title("Week2"));
         AbsolutePath editedPath = AbsolutePath.fromString("/CS2103/Week2");
         blockTree.set(toCs2103Week1, editedBlock);


### PR DESCRIPTION
Closes #170 

Having `InvalidPathException` a checked exception leads to awkward scenarios when we need to wrap the creation of a `Path` objects in unnecessary `try catch` blocks. As it turns out, there have been arguments against the use of checked exceptions too ([one example](http://userstories.blogspot.com/2008/12/checked-exception-why-debat-is-not-over.html))!

This PR does the following:
- [X] Make `InvalidPathException` a `RuntimeException`
- [X] Remove all `throws InvalidPathException` and unnecessary `try catch` block in relation to `InvalidPathException`
- [X] Add Javadoc to `InvalidPathException`