### PR TITLE
Simplify com.notably.commons structure

### DIFF
--- a/src/main/java/com/notably/AppParameters.java
+++ b/src/main/java/com/notably/AppParameters.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.logging.Logger;
 
-import com.notably.commons.core.LogsCenter;
+import com.notably.commons.LogsCenter;
 import com.notably.commons.util.FileUtil;
 
 import javafx.application.Application;

--- a/src/main/java/com/notably/MainApp.java
+++ b/src/main/java/com/notably/MainApp.java
@@ -5,9 +5,9 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.logging.Logger;
 
-import com.notably.commons.core.Config;
-import com.notably.commons.core.LogsCenter;
-import com.notably.commons.core.Version;
+import com.notably.commons.Config;
+import com.notably.commons.LogsCenter;
+import com.notably.commons.Version;
 import com.notably.commons.exceptions.DataConversionException;
 import com.notably.commons.util.ConfigUtil;
 import com.notably.commons.util.StringUtil;

--- a/src/main/java/com/notably/commons/Config.java
+++ b/src/main/java/com/notably/commons/Config.java
@@ -1,4 +1,4 @@
-package com.notably.commons.core;
+package com.notably.commons;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/src/main/java/com/notably/commons/GuiSettings.java
+++ b/src/main/java/com/notably/commons/GuiSettings.java
@@ -1,4 +1,4 @@
-package com.notably.commons.core;
+package com.notably.commons;
 
 import java.awt.Point;
 import java.io.Serializable;

--- a/src/main/java/com/notably/commons/LogsCenter.java
+++ b/src/main/java/com/notably/commons/LogsCenter.java
@@ -1,4 +1,4 @@
-package com.notably.commons.core;
+package com.notably.commons;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/src/main/java/com/notably/commons/Version.java
+++ b/src/main/java/com/notably/commons/Version.java
@@ -1,4 +1,4 @@
-package com.notably.commons.core;
+package com.notably.commons;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/src/main/java/com/notably/commons/index/Index.java
+++ b/src/main/java/com/notably/commons/index/Index.java
@@ -1,4 +1,4 @@
-package com.notably.commons.core.index;
+package com.notably.commons.index;
 
 /**
  * Represents a zero-based or one-based index.

--- a/src/main/java/com/notably/commons/path/AbsolutePath.java
+++ b/src/main/java/com/notably/commons/path/AbsolutePath.java
@@ -1,10 +1,10 @@
-package com.notably.commons.core.path;
+package com.notably.commons.path;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import com.notably.commons.core.path.exceptions.InvalidPathException;
+import com.notably.commons.path.exceptions.InvalidPathException;
 
 /**
  * Represents the Path to a Block, starting from the Root node.

--- a/src/main/java/com/notably/commons/path/Path.java
+++ b/src/main/java/com/notably/commons/path/Path.java
@@ -1,4 +1,4 @@
-package com.notably.commons.core.path;
+package com.notably.commons.path;
 
 import java.util.List;
 

--- a/src/main/java/com/notably/commons/path/RelativePath.java
+++ b/src/main/java/com/notably/commons/path/RelativePath.java
@@ -1,11 +1,11 @@
-package com.notably.commons.core.path;
+package com.notably.commons.path;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import com.notably.commons.core.path.exceptions.InvalidPathException;
+import com.notably.commons.path.exceptions.InvalidPathException;
 
 /**
  * Represents a path to the block relative to the current directory.

--- a/src/main/java/com/notably/commons/path/exceptions/InvalidPathException.java
+++ b/src/main/java/com/notably/commons/path/exceptions/InvalidPathException.java
@@ -1,6 +1,6 @@
-package com.notably.commons.core.path.exceptions;
+package com.notably.commons.path.exceptions;
 
-import com.notably.commons.core.path.Path;
+import com.notably.commons.path.Path;
 
 /**
  * {@link RuntimeException} to be thrown when an invalid representation of a path is supplied during

--- a/src/main/java/com/notably/commons/util/ConfigUtil.java
+++ b/src/main/java/com/notably/commons/util/ConfigUtil.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
 
-import com.notably.commons.core.Config;
+import com.notably.commons.Config;
 import com.notably.commons.exceptions.DataConversionException;
 
 /**

--- a/src/main/java/com/notably/commons/util/JsonUtil.java
+++ b/src/main/java/com/notably/commons/util/JsonUtil.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 
-import com.notably.commons.core.LogsCenter;
+import com.notably.commons.LogsCenter;
 import com.notably.commons.exceptions.DataConversionException;
 
 /**

--- a/src/main/java/com/notably/logic/Logic.java
+++ b/src/main/java/com/notably/logic/Logic.java
@@ -2,7 +2,7 @@ package com.notably.logic;
 
 import java.nio.file.Path;
 
-import com.notably.commons.core.GuiSettings;
+import com.notably.commons.GuiSettings;
 import com.notably.logic.commands.exceptions.CommandException;
 import com.notably.logic.parser.exceptions.ParseException;
 

--- a/src/main/java/com/notably/logic/LogicManager.java
+++ b/src/main/java/com/notably/logic/LogicManager.java
@@ -4,8 +4,8 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.logging.Logger;
 
-import com.notably.commons.core.GuiSettings;
-import com.notably.commons.core.LogsCenter;
+import com.notably.commons.GuiSettings;
+import com.notably.commons.LogsCenter;
 import com.notably.logic.commands.Command;
 import com.notably.logic.commands.exceptions.CommandException;
 import com.notably.logic.parser.NotablyParser;

--- a/src/main/java/com/notably/logic/commands/DeleteCommand.java
+++ b/src/main/java/com/notably/logic/commands/DeleteCommand.java
@@ -2,9 +2,9 @@ package com.notably.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import com.notably.commons.core.path.AbsolutePath;
-import com.notably.commons.core.path.Path;
-import com.notably.commons.core.path.RelativePath;
+import com.notably.commons.path.AbsolutePath;
+import com.notably.commons.path.Path;
+import com.notably.commons.path.RelativePath;
 import com.notably.model.Model;
 
 /**

--- a/src/main/java/com/notably/logic/commands/NewCommand.java
+++ b/src/main/java/com/notably/logic/commands/NewCommand.java
@@ -2,7 +2,7 @@ package com.notably.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import com.notably.commons.core.path.AbsolutePath;
+import com.notably.commons.path.AbsolutePath;
 import com.notably.logic.commands.exceptions.CommandException;
 import com.notably.model.Model;
 import com.notably.model.block.Block;

--- a/src/main/java/com/notably/logic/commands/OpenCommand.java
+++ b/src/main/java/com/notably/logic/commands/OpenCommand.java
@@ -2,7 +2,7 @@ package com.notably.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import com.notably.commons.core.path.AbsolutePath;
+import com.notably.commons.path.AbsolutePath;
 import com.notably.model.Model;
 
 /**

--- a/src/main/java/com/notably/logic/correction/AbsolutePathCorrectionEngine.java
+++ b/src/main/java/com/notably/logic/correction/AbsolutePathCorrectionEngine.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.stream.Collectors;
 
-import com.notably.commons.core.path.AbsolutePath;
+import com.notably.commons.path.AbsolutePath;
 import com.notably.logic.correction.distance.EditDistanceCalculator;
 import com.notably.logic.correction.distance.LevenshteinDistanceCalculator;
 import com.notably.model.Model;

--- a/src/main/java/com/notably/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/DeleteCommandParser.java
@@ -5,7 +5,7 @@ import static com.notably.logic.parser.CliSyntax.PREFIX_TITLE;
 import java.util.List;
 import java.util.Optional;
 
-import com.notably.commons.core.path.AbsolutePath;
+import com.notably.commons.path.AbsolutePath;
 import com.notably.logic.commands.DeleteCommand;
 import com.notably.logic.correction.AbsolutePathCorrectionEngine;
 import com.notably.logic.parser.exceptions.ParseException;

--- a/src/main/java/com/notably/logic/parser/NewCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/NewCommandParser.java
@@ -7,7 +7,7 @@ import static com.notably.logic.parser.CliSyntax.PREFIX_TITLE;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.notably.commons.core.path.AbsolutePath;
+import com.notably.commons.path.AbsolutePath;
 import com.notably.logic.commands.Command;
 import com.notably.logic.commands.NewCommand;
 import com.notably.logic.commands.OpenCommand;

--- a/src/main/java/com/notably/logic/parser/OpenCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/OpenCommandParser.java
@@ -5,7 +5,7 @@ import static com.notably.logic.parser.CliSyntax.PREFIX_TITLE;
 import java.util.List;
 import java.util.Optional;
 
-import com.notably.commons.core.path.AbsolutePath;
+import com.notably.commons.path.AbsolutePath;
 import com.notably.logic.commands.OpenCommand;
 import com.notably.logic.correction.AbsolutePathCorrectionEngine;
 import com.notably.logic.parser.exceptions.ParseException;

--- a/src/main/java/com/notably/logic/parser/ParserUtil.java
+++ b/src/main/java/com/notably/logic/parser/ParserUtil.java
@@ -2,8 +2,8 @@ package com.notably.logic.parser;
 
 import java.util.stream.Stream;
 
-import com.notably.commons.core.path.AbsolutePath;
-import com.notably.commons.core.path.RelativePath;
+import com.notably.commons.path.AbsolutePath;
+import com.notably.commons.path.RelativePath;
 import com.notably.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/com/notably/logic/suggestion/commands/DeleteSuggestionCommand.java
+++ b/src/main/java/com/notably/logic/suggestion/commands/DeleteSuggestionCommand.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import com.notably.commons.core.path.AbsolutePath;
+import com.notably.commons.path.AbsolutePath;
 import com.notably.logic.suggestion.SuggestionCommand;
 import com.notably.model.Model;
 import com.notably.model.block.BlockTreeItem;

--- a/src/main/java/com/notably/logic/suggestion/commands/OpenSuggestionCommand.java
+++ b/src/main/java/com/notably/logic/suggestion/commands/OpenSuggestionCommand.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import com.notably.commons.core.path.AbsolutePath;
+import com.notably.commons.path.AbsolutePath;
 import com.notably.logic.suggestion.SuggestionCommand;
 import com.notably.model.Model;
 import com.notably.model.block.BlockTreeItem;

--- a/src/main/java/com/notably/model/Model.java
+++ b/src/main/java/com/notably/model/Model.java
@@ -2,7 +2,7 @@ package com.notably.model;
 
 import java.nio.file.Path;
 
-import com.notably.commons.core.GuiSettings;
+import com.notably.commons.GuiSettings;
 import com.notably.model.block.BlockModel;
 import com.notably.model.suggestion.SuggestionModel;
 import com.notably.model.viewstate.ViewStateModel;

--- a/src/main/java/com/notably/model/ModelManager.java
+++ b/src/main/java/com/notably/model/ModelManager.java
@@ -8,9 +8,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
 
-import com.notably.commons.core.GuiSettings;
-import com.notably.commons.core.LogsCenter;
-import com.notably.commons.core.path.AbsolutePath;
+import com.notably.commons.GuiSettings;
+import com.notably.commons.LogsCenter;
+import com.notably.commons.path.AbsolutePath;
 import com.notably.model.block.Block;
 import com.notably.model.block.BlockModel;
 import com.notably.model.block.BlockTree;

--- a/src/main/java/com/notably/model/ReadOnlyUserPrefs.java
+++ b/src/main/java/com/notably/model/ReadOnlyUserPrefs.java
@@ -2,7 +2,7 @@ package com.notably.model;
 
 import java.nio.file.Path;
 
-import com.notably.commons.core.GuiSettings;
+import com.notably.commons.GuiSettings;
 
 /**
  * Unmodifiable view of user prefs.

--- a/src/main/java/com/notably/model/UserPrefs.java
+++ b/src/main/java/com/notably/model/UserPrefs.java
@@ -6,7 +6,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
 
-import com.notably.commons.core.GuiSettings;
+import com.notably.commons.GuiSettings;
 
 /**
  * Represents User's preferences.

--- a/src/main/java/com/notably/model/block/BlockModel.java
+++ b/src/main/java/com/notably/model/block/BlockModel.java
@@ -1,6 +1,6 @@
 package com.notably.model.block;
 
-import com.notably.commons.core.path.AbsolutePath;
+import com.notably.commons.path.AbsolutePath;
 
 import javafx.beans.property.Property;
 

--- a/src/main/java/com/notably/model/block/BlockModelImpl.java
+++ b/src/main/java/com/notably/model/block/BlockModelImpl.java
@@ -1,6 +1,6 @@
 package com.notably.model.block;
 
-import com.notably.commons.core.path.AbsolutePath;
+import com.notably.commons.path.AbsolutePath;
 import com.notably.model.block.exceptions.NoSuchBlockException;
 
 import javafx.beans.property.Property;

--- a/src/main/java/com/notably/model/block/BlockTree.java
+++ b/src/main/java/com/notably/model/block/BlockTree.java
@@ -1,6 +1,6 @@
 package com.notably.model.block;
 
-import com.notably.commons.core.path.AbsolutePath;
+import com.notably.commons.path.AbsolutePath;
 
 /**
  * API of BlockTree component.

--- a/src/main/java/com/notably/model/block/BlockTreeImpl.java
+++ b/src/main/java/com/notably/model/block/BlockTreeImpl.java
@@ -2,7 +2,7 @@ package com.notably.model.block;
 
 import static java.util.Objects.requireNonNull;
 
-import com.notably.commons.core.path.AbsolutePath;
+import com.notably.commons.path.AbsolutePath;
 import com.notably.model.block.exceptions.CannotModifyRootException;
 import com.notably.model.block.exceptions.NoSuchBlockException;
 

--- a/src/main/java/com/notably/storage/JsonAddressBookStorage.java
+++ b/src/main/java/com/notably/storage/JsonAddressBookStorage.java
@@ -7,7 +7,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.logging.Logger;
 
-import com.notably.commons.core.LogsCenter;
+import com.notably.commons.LogsCenter;
 import com.notably.commons.exceptions.DataConversionException;
 import com.notably.commons.exceptions.IllegalValueException;
 import com.notably.commons.util.FileUtil;

--- a/src/main/java/com/notably/storage/StorageManager.java
+++ b/src/main/java/com/notably/storage/StorageManager.java
@@ -5,7 +5,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.logging.Logger;
 
-import com.notably.commons.core.LogsCenter;
+import com.notably.commons.LogsCenter;
 import com.notably.commons.exceptions.DataConversionException;
 import com.notably.model.ReadOnlyAddressBook;
 import com.notably.model.ReadOnlyUserPrefs;

--- a/src/main/java/com/notably/view/HelpWindow.java
+++ b/src/main/java/com/notably/view/HelpWindow.java
@@ -2,7 +2,7 @@ package com.notably.view;
 
 import java.util.logging.Logger;
 
-import com.notably.commons.core.LogsCenter;
+import com.notably.commons.LogsCenter;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;

--- a/src/main/java/com/notably/view/MainWindow.java
+++ b/src/main/java/com/notably/view/MainWindow.java
@@ -2,8 +2,8 @@ package com.notably.view;
 
 import java.util.logging.Logger;
 
-import com.notably.commons.core.GuiSettings;
-import com.notably.commons.core.LogsCenter;
+import com.notably.commons.GuiSettings;
+import com.notably.commons.LogsCenter;
 import com.notably.logic.Logic;
 import com.notably.logic.commands.exceptions.CommandException;
 import com.notably.logic.parser.exceptions.ParseException;

--- a/src/main/java/com/notably/view/ViewManager.java
+++ b/src/main/java/com/notably/view/ViewManager.java
@@ -3,7 +3,7 @@ package com.notably.view;
 import java.util.logging.Logger;
 
 import com.notably.MainApp;
-import com.notably.commons.core.LogsCenter;
+import com.notably.commons.LogsCenter;
 import com.notably.commons.util.StringUtil;
 import com.notably.logic.Logic;
 import com.notably.model.Model;

--- a/src/test/java/com/notably/commons/ConfigTest.java
+++ b/src/test/java/com/notably/commons/ConfigTest.java
@@ -1,4 +1,4 @@
-package com.notably.commons.core;
+package com.notably.commons;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/src/test/java/com/notably/commons/VersionTest.java
+++ b/src/test/java/com/notably/commons/VersionTest.java
@@ -1,4 +1,4 @@
-package com.notably.commons.core;
+package com.notably.commons;
 
 import static com.notably.testutil.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/notably/commons/index/IndexTest.java
+++ b/src/test/java/com/notably/commons/index/IndexTest.java
@@ -1,4 +1,4 @@
-package com.notably.commons.core.index;
+package com.notably.commons.index;
 
 import static com.notably.testutil.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/notably/commons/path/AbsolutePathTest.java
+++ b/src/test/java/com/notably/commons/path/AbsolutePathTest.java
@@ -1,4 +1,4 @@
-package com.notably.commons.core.path;
+package com.notably.commons.path;
 
 import static com.notably.testutil.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -8,7 +8,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import com.notably.commons.core.path.exceptions.InvalidPathException;
+import com.notably.commons.path.exceptions.InvalidPathException;
 
 
 class AbsolutePathTest {

--- a/src/test/java/com/notably/commons/path/RelativePathTest.java
+++ b/src/test/java/com/notably/commons/path/RelativePathTest.java
@@ -1,4 +1,4 @@
-package com.notably.commons.core.path;
+package com.notably.commons.path;
 
 import static com.notably.testutil.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -8,7 +8,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import com.notably.commons.core.path.exceptions.InvalidPathException;
+import com.notably.commons.path.exceptions.InvalidPathException;
 
 /**
  * Test for RelativePath.

--- a/src/test/java/com/notably/commons/util/ConfigUtilTest.java
+++ b/src/test/java/com/notably/commons/util/ConfigUtilTest.java
@@ -13,7 +13,7 @@ import java.util.logging.Level;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import com.notably.commons.core.Config;
+import com.notably.commons.Config;
 import com.notably.commons.exceptions.DataConversionException;
 
 public class ConfigUtilTest {

--- a/src/test/java/com/notably/logic/LogicManagerTest.java
+++ b/src/test/java/com/notably/logic/LogicManagerTest.java
@@ -1,8 +1,8 @@
 //TODO: To be enabled or changed when refactoring is completed
 //package com.notably.logic;
 //
-//import static com.notably.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
-//import static com.notably.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+//import static com.notably.commons.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+//import static com.notably.commons.Messages.MESSAGE_UNKNOWN_COMMAND;
 //import static com.notably.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 //import static com.notably.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 //import static com.notably.logic.commands.CommandTestUtil.NAME_DESC_AMY;

--- a/src/test/java/com/notably/logic/correction/AbsolutePathCorrectionEngineTest.java
+++ b/src/test/java/com/notably/logic/correction/AbsolutePathCorrectionEngineTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import com.notably.commons.core.path.AbsolutePath;
+import com.notably.commons.path.AbsolutePath;
 import com.notably.model.Model;
 import com.notably.model.ModelManager;
 import com.notably.model.block.BlockImpl;

--- a/src/test/java/com/notably/logic/parser/NotablyParserTest.java
+++ b/src/test/java/com/notably/logic/parser/NotablyParserTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.notably.commons.core.path.AbsolutePath;
+import com.notably.commons.path.AbsolutePath;
 import com.notably.logic.commands.Command;
 import com.notably.logic.commands.DeleteCommand;
 import com.notably.logic.commands.HelpCommand;

--- a/src/test/java/com/notably/logic/suggestion/commands/DeleteSuggestionCommandTest.java
+++ b/src/test/java/com/notably/logic/suggestion/commands/DeleteSuggestionCommandTest.java
@@ -10,8 +10,8 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import com.notably.commons.core.path.AbsolutePath;
-import com.notably.commons.core.path.exceptions.InvalidPathException;
+import com.notably.commons.path.AbsolutePath;
+import com.notably.commons.path.exceptions.InvalidPathException;
 import com.notably.model.Model;
 import com.notably.model.ModelManager;
 import com.notably.model.block.Block;

--- a/src/test/java/com/notably/logic/suggestion/commands/OpenSuggestionCommandTest.java
+++ b/src/test/java/com/notably/logic/suggestion/commands/OpenSuggestionCommandTest.java
@@ -10,8 +10,8 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import com.notably.commons.core.path.AbsolutePath;
-import com.notably.commons.core.path.exceptions.InvalidPathException;
+import com.notably.commons.path.AbsolutePath;
+import com.notably.commons.path.exceptions.InvalidPathException;
 import com.notably.model.Model;
 import com.notably.model.ModelManager;
 import com.notably.model.block.Block;

--- a/src/test/java/com/notably/model/ModelManagerTest.java
+++ b/src/test/java/com/notably/model/ModelManagerTest.java
@@ -9,7 +9,7 @@
 //
 //import org.junit.jupiter.api.Test;
 //
-//import com.notably.commons.core.GuiSettings;
+//import com.notably.commons.GuiSettings;
 //
 //public class ModelManagerTest {
 //

--- a/src/test/java/com/notably/model/block/BlockModelTest.java
+++ b/src/test/java/com/notably/model/block/BlockModelTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.notably.commons.core.path.AbsolutePath;
+import com.notably.commons.path.AbsolutePath;
 import com.notably.model.block.exceptions.CannotModifyRootException;
 
 import javafx.collections.FXCollections;

--- a/src/test/java/com/notably/model/block/BlockTreeTest.java
+++ b/src/test/java/com/notably/model/block/BlockTreeTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.notably.commons.core.path.AbsolutePath;
+import com.notably.commons.path.AbsolutePath;
 import com.notably.model.block.exceptions.CannotModifyRootException;
 import com.notably.model.block.exceptions.DuplicateBlockException;
 import com.notably.model.block.exceptions.NoSuchBlockException;

--- a/src/test/java/com/notably/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/com/notably/storage/JsonUserPrefsStorageTest.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import com.notably.commons.core.GuiSettings;
+import com.notably.commons.GuiSettings;
 import com.notably.commons.exceptions.DataConversionException;
 import com.notably.model.UserPrefs;
 

--- a/src/test/java/com/notably/storage/StorageManagerTest.java
+++ b/src/test/java/com/notably/storage/StorageManagerTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import com.notably.commons.core.GuiSettings;
+import com.notably.commons.GuiSettings;
 import com.notably.model.UserPrefs;
 
 public class StorageManagerTest {

--- a/src/test/java/com/notably/testutil/TypicalIndexes.java
+++ b/src/test/java/com/notably/testutil/TypicalIndexes.java
@@ -1,6 +1,6 @@
 package com.notably.testutil;
 
-import com.notably.commons.core.index.Index;
+import com.notably.commons.index.Index;
 
 /**
  * A utility class containing a list of {@code Index} objects to be used in tests.


### PR DESCRIPTION
The previous AB3 `commons` package is structured as:
- `com.notably.commons.core`
- `com.notably.commons.exceptions`
- `com.notably.commons.util`

All the application logic related codes, such as `LogsCenter`, `Version`, etc., are located under the `com.notably.commons.core` package. However, this is rather unnecessary, since we can similarly place all the codes under the `com.notably.commons` package (without the `core` portion) and everything will still be very understandable.

In this PR, I have removed the `com.notably.commons.core` package, and placed all the files (and packages) previously under `com.notably.commons.core` into the `com.notably.commons` package. This will:
- Simplify our directory structure, since now there is one less nested directory in our codebase, and
- Improve consistency throughout our codebase, since we similarly don't have any `core` packages under our other packages. For example, we don't have `com.notably.logic.correction.core` nor `com.notably.model.block.core`; we place our codes directly under the `com.notably.logic.correction` and `com.notably.model.block` packages.

@AY1920S2-CS2103T-W17-2/developers what do you guys think?