### PR TITLE
Implement Markdown to HTML compiler

### DIFF
--- a/src/main/java/com/notably/commons/compiler/tokenizer/Token.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/Token.java
@@ -1,0 +1,55 @@
+package com.notably.commons.compiler.tokenizer;
+
+import java.util.Objects;
+
+/**
+ * TODO: Add Javadoc
+ */
+public class Token {
+    public static final Token MINUS = new Token(TokenType.MINUS, "-");
+    public static final Token HASH = new Token(TokenType.HASH, "#");
+    public static final Token CR = new Token(TokenType.CR, "\r");
+    public static final Token LF = new Token(TokenType.LF, "\n");
+    public static final Token SPACE = new Token(TokenType.SPACE, " ");
+    public static final Token EOF = new Token(TokenType.EOF, "");
+
+    private final TokenType type;
+    private final String value;
+
+    public Token(TokenType type, String value) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(value);
+
+        this.type = type;
+        this.value = value;
+    }
+
+    public TokenType getType() {
+        return type;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public int getLength() {
+        return value.length();
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof Token)) {
+            return false;
+        }
+
+        Token anotherToken = (Token) object;
+        return Objects.equals(type, anotherToken.type)
+                && Objects.equals(value, anotherToken.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, value);
+    }
+}
+

--- a/src/main/java/com/notably/commons/compiler/tokenizer/Token.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/Token.java
@@ -3,7 +3,7 @@ package com.notably.commons.compiler.tokenizer;
 import java.util.Objects;
 
 /**
- * TODO: Add Javadoc
+ * A representation of a single/a bunch of character(s) in a standalone form.
  */
 public class Token {
     public static final Token MINUS = new Token(TokenType.MINUS, "-");

--- a/src/main/java/com/notably/commons/compiler/tokenizer/TokenType.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/TokenType.java
@@ -1,7 +1,7 @@
 package com.notably.commons.compiler.tokenizer;
 
 /**
- * TODO: Add Javadoc
+ * Represents the possible types of {@link Token}s.
  */
 public enum TokenType {
     MINUS,

--- a/src/main/java/com/notably/commons/compiler/tokenizer/TokenType.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/TokenType.java
@@ -1,0 +1,15 @@
+package com.notably.commons.compiler.tokenizer;
+
+/**
+ * TODO: Add Javadoc
+ */
+public enum TokenType {
+    MINUS,
+    HASH,
+    CR,
+    LF,
+    SPACE,
+    TEXT,
+    EOF;
+}
+

--- a/src/main/java/com/notably/commons/compiler/tokenizer/Tokenizer.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/Tokenizer.java
@@ -14,7 +14,7 @@ import com.notably.commons.compiler.tokenizer.rule.SpaceRule;
 import com.notably.commons.compiler.tokenizer.rule.TextRule;
 
 /**
- * TODO: Add Javadoc
+ * A class capable of breaking down a plain string into a sequence of {@link Token}s.
  */
 public class Tokenizer {
     private static final List<Rule> RULES = List.of(
@@ -27,7 +27,10 @@ public class Tokenizer {
     );
 
     /**
-     * TODO: Add Javadoc
+     * Breaks down a string input into a list of {@link Token}s.
+     *
+     * @param input A string input
+     * @return A list of {@link Token}s
      */
     public static List<Token> tokenize(String input) {
         String remainingInput = input;

--- a/src/main/java/com/notably/commons/compiler/tokenizer/Tokenizer.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/Tokenizer.java
@@ -37,11 +37,11 @@ public class Tokenizer {
         List<Token> tokens = new ArrayList<>();
 
         while (remainingInput.length() > 0) {
-            int i = 0;
-            Optional<Token> nextTokenOptional = RULES.get(i).extractFront(remainingInput);
-            while (nextTokenOptional.isEmpty() && i < RULES.size()) {
-                nextTokenOptional = RULES.get(i).extractFront(remainingInput);
-                i += 1;
+            int ruleIndex = 0;
+            Optional<Token> nextTokenOptional = RULES.get(ruleIndex).extractFront(remainingInput);
+            while (nextTokenOptional.isEmpty() && ruleIndex < RULES.size()) {
+                nextTokenOptional = RULES.get(ruleIndex).extractFront(remainingInput);
+                ruleIndex += 1;
             }
 
             Token nextToken = nextTokenOptional.orElseThrow(UnknownTokenException::new);

--- a/src/main/java/com/notably/commons/compiler/tokenizer/Tokenizer.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/Tokenizer.java
@@ -1,0 +1,55 @@
+package com.notably.commons.compiler.tokenizer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.notably.commons.compiler.tokenizer.exceptions.UnknownTokenException;
+import com.notably.commons.compiler.tokenizer.rule.CarriageReturnRule;
+import com.notably.commons.compiler.tokenizer.rule.HashRule;
+import com.notably.commons.compiler.tokenizer.rule.LineFeedRule;
+import com.notably.commons.compiler.tokenizer.rule.MinusRule;
+import com.notably.commons.compiler.tokenizer.rule.Rule;
+import com.notably.commons.compiler.tokenizer.rule.SpaceRule;
+import com.notably.commons.compiler.tokenizer.rule.TextRule;
+
+/**
+ * TODO: Add Javadoc
+ */
+public class Tokenizer {
+    private static final List<Rule> RULES = List.of(
+            new MinusRule(),
+            new HashRule(),
+            new SpaceRule(),
+            new CarriageReturnRule(),
+            new LineFeedRule(),
+            new TextRule()
+    );
+
+    /**
+     * TODO: Add Javadoc
+     */
+    public static List<Token> tokenize(String input) {
+        String remainingInput = input;
+        List<Token> tokens = new ArrayList<>();
+
+        while (remainingInput.length() > 0) {
+            int i = 0;
+            Optional<Token> nextTokenOptional = RULES.get(i).extractFront(remainingInput);
+            while (nextTokenOptional.isEmpty() && i < RULES.size()) {
+                nextTokenOptional = RULES.get(i).extractFront(remainingInput);
+                i += 1;
+            }
+
+            Token nextToken = nextTokenOptional.orElseThrow(UnknownTokenException::new);
+            tokens.add(nextToken);
+
+            remainingInput = remainingInput.substring(nextToken.getLength());
+        }
+
+        tokens.add(Token.EOF);
+
+        return tokens;
+    }
+}
+

--- a/src/main/java/com/notably/commons/compiler/tokenizer/exceptions/UnknownTokenException.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/exceptions/UnknownTokenException.java
@@ -1,7 +1,9 @@
 package com.notably.commons.compiler.tokenizer.exceptions;
 
+import com.notably.commons.compiler.tokenizer.Tokenizer;
+
 /**
- * TODO: Add Javadoc
+ * Represents an error thrown when an unknown token is encountered by {@link Tokenizer}.
  */
 public class UnknownTokenException extends RuntimeException {
     public UnknownTokenException() {

--- a/src/main/java/com/notably/commons/compiler/tokenizer/exceptions/UnknownTokenException.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/exceptions/UnknownTokenException.java
@@ -1,0 +1,15 @@
+package com.notably.commons.compiler.tokenizer.exceptions;
+
+/**
+ * TODO: Add Javadoc
+ */
+public class UnknownTokenException extends RuntimeException {
+    public UnknownTokenException() {
+        super();
+    }
+
+    public UnknownTokenException(String message) {
+        super(message);
+    }
+}
+

--- a/src/main/java/com/notably/commons/compiler/tokenizer/rule/CarriageReturnRule.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/rule/CarriageReturnRule.java
@@ -1,0 +1,24 @@
+package com.notably.commons.compiler.tokenizer.rule;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.notably.commons.compiler.tokenizer.Token;
+
+/**
+ * TODO: Add Javadoc
+ */
+public class CarriageReturnRule implements Rule {
+    private static final Pattern PATTERN = Pattern.compile("^\\r");
+
+    @Override
+    public Optional<Token> extractFront(String input) {
+        Matcher matcher = PATTERN.matcher(input);
+        if (!matcher.find()) {
+            return Optional.empty();
+        }
+        return Optional.of(Token.CR);
+    }
+}
+

--- a/src/main/java/com/notably/commons/compiler/tokenizer/rule/CarriageReturnRule.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/rule/CarriageReturnRule.java
@@ -7,7 +7,8 @@ import java.util.regex.Pattern;
 import com.notably.commons.compiler.tokenizer.Token;
 
 /**
- * TODO: Add Javadoc
+ * Represents a rule that dictates how to convert a single carriage return character into a carriage return
+ * {@link Token}.
  */
 public class CarriageReturnRule implements Rule {
     private static final Pattern PATTERN = Pattern.compile("^\\r");

--- a/src/main/java/com/notably/commons/compiler/tokenizer/rule/HashRule.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/rule/HashRule.java
@@ -1,0 +1,24 @@
+package com.notably.commons.compiler.tokenizer.rule;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.notably.commons.compiler.tokenizer.Token;
+
+/**
+ * TODO: Add Javadoc
+ */
+public class HashRule implements Rule {
+    private static final Pattern PATTERN = Pattern.compile("^#");
+
+    @Override
+    public Optional<Token> extractFront(String input) {
+        Matcher matcher = PATTERN.matcher(input);
+        if (!matcher.find()) {
+            return Optional.empty();
+        }
+        return Optional.of(Token.HASH);
+    }
+}
+

--- a/src/main/java/com/notably/commons/compiler/tokenizer/rule/HashRule.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/rule/HashRule.java
@@ -7,7 +7,7 @@ import java.util.regex.Pattern;
 import com.notably.commons.compiler.tokenizer.Token;
 
 /**
- * TODO: Add Javadoc
+ * Represents a rule that dictates how to convert a single hash character into a hash {@link Token}.
  */
 public class HashRule implements Rule {
     private static final Pattern PATTERN = Pattern.compile("^#");

--- a/src/main/java/com/notably/commons/compiler/tokenizer/rule/LineFeedRule.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/rule/LineFeedRule.java
@@ -1,0 +1,24 @@
+package com.notably.commons.compiler.tokenizer.rule;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.notably.commons.compiler.tokenizer.Token;
+
+/**
+ * TODO: Add Javadoc
+ */
+public class LineFeedRule implements Rule {
+    private static final Pattern PATTERN = Pattern.compile("^\\n");
+
+    @Override
+    public Optional<Token> extractFront(String input) {
+        Matcher matcher = PATTERN.matcher(input);
+        if (!matcher.find()) {
+            return Optional.empty();
+        }
+        return Optional.of(Token.LF);
+    }
+}
+

--- a/src/main/java/com/notably/commons/compiler/tokenizer/rule/LineFeedRule.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/rule/LineFeedRule.java
@@ -7,7 +7,7 @@ import java.util.regex.Pattern;
 import com.notably.commons.compiler.tokenizer.Token;
 
 /**
- * TODO: Add Javadoc
+ * Represents a rule that dictates how to convert a single line feed character into a line feed {@link Token}.
  */
 public class LineFeedRule implements Rule {
     private static final Pattern PATTERN = Pattern.compile("^\\n");

--- a/src/main/java/com/notably/commons/compiler/tokenizer/rule/MinusRule.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/rule/MinusRule.java
@@ -7,7 +7,7 @@ import java.util.regex.Pattern;
 import com.notably.commons.compiler.tokenizer.Token;
 
 /**
- * TODO: Add Javadoc
+ * Represents a rule that dictates how to convert a minus hash character into a minus {@link Token}.
  */
 public class MinusRule implements Rule {
     private static final Pattern PATTERN = Pattern.compile("^-");

--- a/src/main/java/com/notably/commons/compiler/tokenizer/rule/MinusRule.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/rule/MinusRule.java
@@ -1,0 +1,24 @@
+package com.notably.commons.compiler.tokenizer.rule;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.notably.commons.compiler.tokenizer.Token;
+
+/**
+ * TODO: Add Javadoc
+ */
+public class MinusRule implements Rule {
+    private static final Pattern PATTERN = Pattern.compile("^-");
+
+    @Override
+    public Optional<Token> extractFront(String input) {
+        Matcher matcher = PATTERN.matcher(input);
+        if (!matcher.find()) {
+            return Optional.empty();
+        }
+        return Optional.of(Token.MINUS);
+    }
+}
+

--- a/src/main/java/com/notably/commons/compiler/tokenizer/rule/Rule.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/rule/Rule.java
@@ -1,0 +1,16 @@
+package com.notably.commons.compiler.tokenizer.rule;
+
+import java.util.Optional;
+
+import com.notably.commons.compiler.tokenizer.Token;
+
+/**
+ * TODO: Add Javadoc
+ */
+public interface Rule {
+    /**
+     * TODO: Add Javadoc
+     */
+    Optional<Token> extractFront(String input);
+}
+

--- a/src/main/java/com/notably/commons/compiler/tokenizer/rule/Rule.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/rule/Rule.java
@@ -5,11 +5,14 @@ import java.util.Optional;
 import com.notably.commons.compiler.tokenizer.Token;
 
 /**
- * TODO: Add Javadoc
+ * Represents a rule that dictates how to convert a single/a bunch of characters into a single {@link Token}.
  */
 public interface Rule {
     /**
-     * TODO: Add Javadoc
+     * Extracts a single {@link Token}, if possible, from the front of an input string.
+     *
+     * @param input Input string
+     * @return An extracted {@link Token}, or {@code Optional.empty()} if unsuccessful
      */
     Optional<Token> extractFront(String input);
 }

--- a/src/main/java/com/notably/commons/compiler/tokenizer/rule/SpaceRule.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/rule/SpaceRule.java
@@ -1,0 +1,24 @@
+package com.notably.commons.compiler.tokenizer.rule;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.notably.commons.compiler.tokenizer.Token;
+
+/**
+ * TODO: Add Javadoc
+ */
+public class SpaceRule implements Rule {
+    private static final Pattern PATTERN = Pattern.compile("^ ");
+
+    @Override
+    public Optional<Token> extractFront(String input) {
+        Matcher matcher = PATTERN.matcher(input);
+        if (!matcher.find()) {
+            return Optional.empty();
+        }
+        return Optional.of(Token.SPACE);
+    }
+}
+

--- a/src/main/java/com/notably/commons/compiler/tokenizer/rule/SpaceRule.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/rule/SpaceRule.java
@@ -7,7 +7,7 @@ import java.util.regex.Pattern;
 import com.notably.commons.compiler.tokenizer.Token;
 
 /**
- * TODO: Add Javadoc
+ * Represents a rule that dictates how to convert a single space character into a space {@link Token}.
  */
 public class SpaceRule implements Rule {
     private static final Pattern PATTERN = Pattern.compile("^ ");

--- a/src/main/java/com/notably/commons/compiler/tokenizer/rule/TextRule.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/rule/TextRule.java
@@ -8,7 +8,7 @@ import com.notably.commons.compiler.tokenizer.Token;
 import com.notably.commons.compiler.tokenizer.TokenType;
 
 /**
- * TODO: Add Javadoc
+ * Represents a rule that dictates how to convert a bunch of characters into a text {@link Token}.
  */
 public class TextRule implements Rule {
     private static final Pattern PATTERN = Pattern.compile("^([^-# \\r\\n]+)");

--- a/src/main/java/com/notably/commons/compiler/tokenizer/rule/TextRule.java
+++ b/src/main/java/com/notably/commons/compiler/tokenizer/rule/TextRule.java
@@ -1,0 +1,25 @@
+package com.notably.commons.compiler.tokenizer.rule;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.notably.commons.compiler.tokenizer.Token;
+import com.notably.commons.compiler.tokenizer.TokenType;
+
+/**
+ * TODO: Add Javadoc
+ */
+public class TextRule implements Rule {
+    private static final Pattern PATTERN = Pattern.compile("^([^-# \\r\\n]+)");
+
+    @Override
+    public Optional<Token> extractFront(String input) {
+        Matcher matcher = PATTERN.matcher(input);
+        if (!matcher.find()) {
+            return Optional.empty();
+        }
+        return Optional.of(new Token(TokenType.TEXT, matcher.group(1)));
+    }
+}
+

--- a/src/test/java/com/notably/commons/compiler/tokenizer/TokenizerTest.java
+++ b/src/test/java/com/notably/commons/compiler/tokenizer/TokenizerTest.java
@@ -1,0 +1,34 @@
+package com.notably.commons.compiler.tokenizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class TokenizerTest {
+    @Test
+    public void tokenize() {
+        final String input = "## 2nd-level header \r\n";
+
+        final List<Token> expectedTokens = List.of(
+                Token.HASH,
+                Token.HASH,
+                Token.SPACE,
+                new Token(TokenType.TEXT, "2nd"),
+                Token.MINUS,
+                new Token(TokenType.TEXT, "level"),
+                Token.SPACE,
+                new Token(TokenType.TEXT, "header"),
+                Token.SPACE,
+                Token.CR,
+                Token.LF,
+                Token.EOF
+        );
+
+        List<Token> tokens = Tokenizer.tokenize(input);
+
+        assertEquals(expectedTokens, tokens);
+    }
+}
+


### PR DESCRIPTION
Closes #255 

This PR:
- [x] Implements a `Tokenizer` which tokenize plain string into tokens.
- [x] Write test cases for the `Tokenizer` implementation.

As of now, this `Tokenizer` only supports a subset of the proposed markdown syntax (see #162).