### PR TITLE
Add DeleteSuggestionCommandParser and DeleteSuggestionCommandParserTest

### DIFF
--- a/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
@@ -38,12 +38,17 @@ public class DeleteSuggestionCommandParser implements SuggestionCommandParser<De
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(userInput, PREFIX_TITLE);
 
+        String title;
         if (!ParserUtil.arePrefixesPresent(argMultimap, PREFIX_TITLE)
                 || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format("Invalid input"));
+            title = userInput.trim();
+            if (title.isEmpty()) {
+                throw new ParseException("Path cannot be empty");
+            }
+        } else {
+            title = argMultimap.getValue(PREFIX_TITLE).get();
         }
 
-        String title = argMultimap.getValue(PREFIX_TITLE).get();
         AbsolutePath uncorrectedPath = ParserUtil.createAbsolutePath(title, model.getCurrentlyOpenPath());
         Optional<AbsolutePath> correctedPath = correctionEngine.correct(uncorrectedPath).getCorrectedItem();
 

--- a/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
@@ -1,0 +1,56 @@
+package com.notably.logic.parser.suggestion;
+
+import static com.notably.logic.parser.CliSyntax.PREFIX_TITLE;
+
+import java.util.Optional;
+
+import com.notably.commons.path.AbsolutePath;
+import com.notably.logic.commands.suggestion.DeleteSuggestionCommand;
+import com.notably.logic.correction.AbsolutePathCorrectionEngine;
+import com.notably.logic.parser.ArgumentMultimap;
+import com.notably.logic.parser.ArgumentTokenizer;
+import com.notably.logic.parser.ParserUtil;
+import com.notably.logic.parser.exceptions.ParseException;
+import com.notably.model.Model;
+
+/**
+ * Represents a Parser for DeleteSuggestionCommand.
+ */
+public class DeleteSuggestionCommandParser implements SuggestionCommandParser<DeleteSuggestionCommand> {
+    private static final int DISTANCE_THRESHOLD = 2;
+
+    private Model model;
+    private AbsolutePathCorrectionEngine correctionEngine;
+
+    public DeleteSuggestionCommandParser(Model model) {
+        this.model = model;
+        this.correctionEngine = new AbsolutePathCorrectionEngine(model, DISTANCE_THRESHOLD);
+    }
+
+    /**
+     * Parses user input in the context of the DeleteSuggestionCommand.
+     * @param userInput The user's input.
+     * @return A DeleteSuggestionCommand object with a corrected absolute path.
+     * @throws ParseException if the user input path cannot be found.
+     */
+    @Override
+    public DeleteSuggestionCommand parse(String userInput) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(userInput, PREFIX_TITLE);
+
+        if (!ParserUtil.arePrefixesPresent(argMultimap, PREFIX_TITLE)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format("Invalid input"));
+        }
+
+        String titles = argMultimap.getValue(PREFIX_TITLE).get();
+        AbsolutePath uncorrectedPath = ParserUtil.createAbsolutePath(titles, model.getCurrentlyOpenPath());
+        Optional<AbsolutePath> correctedPath = correctionEngine.correct(uncorrectedPath).getCorrectedItem();
+
+        if (correctedPath.equals(Optional.empty())) {
+            throw new ParseException("Invalid path");
+        }
+
+        return new DeleteSuggestionCommand(correctedPath.get());
+    }
+}

--- a/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
@@ -43,14 +43,12 @@ public class DeleteSuggestionCommandParser implements SuggestionCommandParser<De
             throw new ParseException(String.format("Invalid input"));
         }
 
-        String titles = argMultimap.getValue(PREFIX_TITLE).get();
-        AbsolutePath uncorrectedPath = ParserUtil.createAbsolutePath(titles, model.getCurrentlyOpenPath());
+        String title = argMultimap.getValue(PREFIX_TITLE).get();
+        AbsolutePath uncorrectedPath = ParserUtil.createAbsolutePath(title, model.getCurrentlyOpenPath());
         Optional<AbsolutePath> correctedPath = correctionEngine.correct(uncorrectedPath).getCorrectedItem();
 
-        if (correctedPath.equals(Optional.empty())) {
-            throw new ParseException("Invalid path");
-        }
-
-        return new DeleteSuggestionCommand(correctedPath.get());
+        return correctedPath
+                .map(DeleteSuggestionCommand::new)
+                .orElseThrow(() -> new ParseException("Invalid path"));
     }
 }

--- a/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
@@ -24,7 +24,7 @@ public class DeleteSuggestionCommandParser implements SuggestionCommandParser<De
 
     public DeleteSuggestionCommandParser(Model model) {
         this.model = model;
-        this.correctionEngine = new AbsolutePathCorrectionEngine(model, DISTANCE_THRESHOLD);
+        this.correctionEngine = new AbsolutePathCorrectionEngine(model, DISTANCE_THRESHOLD, true);
     }
 
     /**
@@ -42,9 +42,6 @@ public class DeleteSuggestionCommandParser implements SuggestionCommandParser<De
         if (!ParserUtil.arePrefixesPresent(argMultimap, PREFIX_TITLE)
                 || !argMultimap.getPreamble().isEmpty()) {
             title = userInput.trim();
-            if (title.isEmpty()) {
-                throw new ParseException("Path cannot be empty");
-            }
         } else {
             title = argMultimap.getValue(PREFIX_TITLE).get();
         }

--- a/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
@@ -31,7 +31,7 @@ public class DeleteSuggestionCommandParser implements SuggestionCommandParser<De
      * Parses user input in the context of the DeleteSuggestionCommand.
      * @param userInput The user's input.
      * @return A DeleteSuggestionCommand object with a corrected absolute path.
-     * @throws ParseException if the user input path cannot be found.
+     * @throws ParseException if the user input is in a wrong format and/ or path cannot be found.
      */
     @Override
     public DeleteSuggestionCommand parse(String userInput) throws ParseException {

--- a/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
@@ -53,7 +53,7 @@ public class DeleteSuggestionCommandParser implements SuggestionCommandParser<De
         Optional<AbsolutePath> correctedPath = correctionEngine.correct(uncorrectedPath).getCorrectedItem();
 
         return correctedPath
-                .map(DeleteSuggestionCommand::new)
+                .map((AbsolutePath path) -> new DeleteSuggestionCommand(path, title))
                 .orElseThrow(() -> new ParseException("Invalid path"));
     }
 }

--- a/src/main/java/com/notably/logic/suggestion/SuggestionEngineImpl.java
+++ b/src/main/java/com/notably/logic/suggestion/SuggestionEngineImpl.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.notably.logic.commands.suggestion.DeleteSuggestionCommand;
 import com.notably.logic.commands.suggestion.EditSuggestionCommand;
 import com.notably.logic.commands.suggestion.ErrorSuggestionCommand;
 import com.notably.logic.commands.suggestion.ExitSuggestionCommand;
@@ -14,6 +15,7 @@ import com.notably.logic.commands.suggestion.OpenSuggestionCommand;
 import com.notably.logic.commands.suggestion.SuggestionCommand;
 import com.notably.logic.correction.StringCorrectionEngine;
 import com.notably.logic.parser.exceptions.ParseException;
+import com.notably.logic.parser.suggestion.DeleteSuggestionCommandParser;
 import com.notably.logic.parser.suggestion.OpenSuggestionCommandParser;
 import com.notably.model.Model;
 
@@ -78,10 +80,14 @@ public class SuggestionEngineImpl implements SuggestionEngine {
                 return new ErrorSuggestionCommand(e.getMessage());
             }
 
-        /*case DeleteSuggestionCommand.COMMAND_WORD:
-            return new DeleteSuggestionCommandParser(model).parse(arguments);
+        case DeleteSuggestionCommand.COMMAND_WORD:
+            try {
+                return new DeleteSuggestionCommandParser(model).parse(arguments);
+            } catch (ParseException e) {
+                return new ErrorSuggestionCommand(e.getMessage());
+            }
 
-        case SearchSuggestionCommand.COMMAND_WORD:
+        /*case SearchSuggestionCommand.COMMAND_WORD:
             return new SearchSuggestionCommandParser(model).parse(arguments);*/
 
         case NewSuggestionCommand.COMMAND_WORD:

--- a/src/test/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParserTest.java
+++ b/src/test/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParserTest.java
@@ -1,0 +1,194 @@
+package com.notably.logic.parser.suggestion;
+
+import static com.notably.logic.parser.suggestion.SuggestionCommandParserTestUtil.assertParseFailure;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.notably.commons.path.AbsolutePath;
+import com.notably.logic.commands.suggestion.DeleteSuggestionCommand;
+import com.notably.logic.commands.suggestion.SuggestionCommand;
+import com.notably.logic.parser.exceptions.ParseException;
+import com.notably.model.Model;
+import com.notably.model.ModelManager;
+import com.notably.model.block.Block;
+import com.notably.model.block.BlockImpl;
+import com.notably.model.block.BlockModel;
+import com.notably.model.block.BlockModelImpl;
+import com.notably.model.block.Title;
+import com.notably.model.suggestion.SuggestionItem;
+import com.notably.model.suggestion.SuggestionItemImpl;
+import com.notably.model.suggestion.SuggestionModel;
+import com.notably.model.suggestion.SuggestionModelImpl;
+import com.notably.model.viewstate.ViewStateModel;
+import com.notably.model.viewstate.ViewStateModelImpl;
+
+public class DeleteSuggestionCommandParserTest {
+    private static AbsolutePath toRoot;
+    private static AbsolutePath toCs2103;
+    private static AbsolutePath toCs3230;
+    private static AbsolutePath toCs2103Week1;
+    private static AbsolutePath toCs2103Week2;
+    private static AbsolutePath toCs2103Week3;
+    private static AbsolutePath toCs2103Week1Lecture;
+    private static Model model;
+    private static DeleteSuggestionCommandParser deleteSuggestionCommandParser;
+
+    private static final String COMMAND_WORD = "delete";
+    private static final String PREFIX_TITLE = "-t";
+    private static final String RESPONSE_MESSAGE = "Delete a note";
+
+    @BeforeAll
+    public static void setUp() {
+        // Set up paths
+        toRoot = AbsolutePath.fromString("/");
+        toCs2103 = AbsolutePath.fromString("/CS2103");
+        toCs3230 = AbsolutePath.fromString("/CS3230");
+        toCs2103Week1 = AbsolutePath.fromString("/CS2103/Week1");
+        toCs2103Week2 = AbsolutePath.fromString("/CS2103/Week2");
+        toCs2103Week3 = AbsolutePath.fromString("/CS2103/Week3");
+        toCs2103Week1Lecture = AbsolutePath.fromString("/CS2103/Week1/Lecture");
+
+        // Set up model
+        BlockModel blockModel = new BlockModelImpl();
+        SuggestionModel suggestionModel = new SuggestionModelImpl();
+        ViewStateModel viewStateModel = new ViewStateModelImpl();
+        model = new ModelManager(blockModel, suggestionModel, viewStateModel);
+
+        // Add test data to model
+        Block cs2103 = new BlockImpl(new Title("CS2103"));
+        Block cs3230 = new BlockImpl(new Title("CS3230"));
+        model.addBlockToCurrentPath(cs2103);
+        model.addBlockToCurrentPath(cs3230);
+
+        Block week1 = new BlockImpl(new Title("Week1"));
+        Block week2 = new BlockImpl(new Title("Week2"));
+        Block week3 = new BlockImpl(new Title("Week3"));
+        model.setCurrentlyOpenBlock(toCs2103);
+        model.addBlockToCurrentPath(week1);
+        model.addBlockToCurrentPath(week2);
+        model.addBlockToCurrentPath(week3);
+
+        Block lecture = new BlockImpl(new Title("Lecture"));
+        model.setCurrentlyOpenBlock(toCs2103Week1);
+        model.addBlockToCurrentPath(lecture);
+
+        // initialize parser
+        deleteSuggestionCommandParser = new DeleteSuggestionCommandParser(model);
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(deleteSuggestionCommandParser, " /CS2103",
+            "Invalid input");
+
+        assertParseFailure(deleteSuggestionCommandParser, " /CS2 103",
+                "Invalid input");
+
+        assertParseFailure(deleteSuggestionCommandParser, " preamble -t /CS2103",
+            "Invalid input");
+    }
+
+    @Test
+    public void parse_uncorrectedPath_throwsParseException() {
+        assertParseFailure(deleteSuggestionCommandParser, " -t randomBlock", "Invalid path");
+    }
+
+    @Test
+    public void parse_correctPath_returnsDeleteSuggestionCommand() throws ParseException {
+        SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(" -t /CS2103");
+        assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
+
+        commandCorrectPath.execute(model);
+
+        assertEquals(Optional.of(RESPONSE_MESSAGE), model.responseTextProperty().getValue());
+
+        // Expected result
+        SuggestionItem cs2103 = new SuggestionItemImpl(toCs2103.getStringRepresentation(), null);
+        SuggestionItem cs2103Week1Lecture = new SuggestionItemImpl(toCs2103Week1Lecture.getStringRepresentation(),
+                null);
+        SuggestionItem cs2103Week2 = new SuggestionItemImpl(toCs2103Week2.getStringRepresentation(), null);
+        SuggestionItem cs2103Week3 = new SuggestionItemImpl(toCs2103Week3.getStringRepresentation(), null);
+
+        List<SuggestionItem> expectedSuggestions = new ArrayList<>();
+        expectedSuggestions.add(cs2103);
+        expectedSuggestions.add(cs2103Week1Lecture);
+        expectedSuggestions.add(cs2103Week2);
+        expectedSuggestions.add(cs2103Week3);
+
+        List<SuggestionItem> suggestions = model.getSuggestions();
+
+        // check display text
+        for (int i = 0; i < expectedSuggestions.size(); i++) {
+            SuggestionItem suggestion = suggestions.get(i);
+            SuggestionItem expectedSuggestion = expectedSuggestions.get(i);
+            assertEquals(expectedSuggestion.getProperty("displayText"), suggestion.getProperty("displayText"));
+        }
+
+        List<String> expectedInputs = new ArrayList<>();
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week1Lecture.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week2.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week3.getStringRepresentation());
+
+        for (int i = 0; i < expectedInputs.size(); i++) {
+            SuggestionItem suggestionItem = suggestions.get(i);
+            String expectedInput = expectedInputs.get(i);
+            suggestionItem.getAction().run();
+            String input = model.getInput();
+            assertEquals(expectedInput, input);
+        }
+    }
+
+    @Test
+    public void parse_correctedPath_returnsDeleteSuggestionCommand() throws ParseException {
+        SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(" -t /CS2104");
+        assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
+
+        commandCorrectPath.execute(model);
+
+        assertEquals(Optional.of(RESPONSE_MESSAGE), model.responseTextProperty().getValue());
+
+        // Expected result
+        SuggestionItem cs2103 = new SuggestionItemImpl(toCs2103.getStringRepresentation(), null);
+        SuggestionItem cs2103Week1Lecture = new SuggestionItemImpl(toCs2103Week1Lecture.getStringRepresentation(),
+                null);
+        SuggestionItem cs2103Week2 = new SuggestionItemImpl(toCs2103Week2.getStringRepresentation(), null);
+        SuggestionItem cs2103Week3 = new SuggestionItemImpl(toCs2103Week3.getStringRepresentation(), null);
+
+        List<SuggestionItem> expectedSuggestions = new ArrayList<>();
+        expectedSuggestions.add(cs2103);
+        expectedSuggestions.add(cs2103Week1Lecture);
+        expectedSuggestions.add(cs2103Week2);
+        expectedSuggestions.add(cs2103Week3);
+
+        List<SuggestionItem> suggestions = model.getSuggestions();
+
+        // check display text
+        for (int i = 0; i < expectedSuggestions.size(); i++) {
+            SuggestionItem suggestion = suggestions.get(i);
+            SuggestionItem expectedSuggestion = expectedSuggestions.get(i);
+            assertEquals(expectedSuggestion.getProperty("displayText"), suggestion.getProperty("displayText"));
+        }
+
+        List<String> expectedInputs = new ArrayList<>();
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week1Lecture.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week2.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week3.getStringRepresentation());
+
+        for (int i = 0; i < expectedInputs.size(); i++) {
+            SuggestionItem suggestionItem = suggestions.get(i);
+            String expectedInput = expectedInputs.get(i);
+            suggestionItem.getAction().run();
+            String input = model.getInput();
+            assertEquals(expectedInput, input);
+        }
+    }
+}

--- a/src/test/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParserTest.java
+++ b/src/test/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParserTest.java
@@ -96,6 +96,8 @@ public class DeleteSuggestionCommandParserTest {
 
     @Test
     public void parse_correctPathWithPrefix_returnsDeleteSuggestionCommand() throws ParseException {
+        model.setInput("delete -t /CS2103");
+
         SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(" -t /CS2103");
         assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
 
@@ -142,7 +144,57 @@ public class DeleteSuggestionCommandParserTest {
 
     @Test
     public void parse_correctPathWithoutPrefix_returnsDeleteSuggestionCommand() throws ParseException {
+        model.setInput("delete /CS2103");
+
         SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(" /CS2103");
+        assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
+
+        commandCorrectPath.execute(model);
+
+        assertEquals(Optional.of(RESPONSE_MESSAGE), model.responseTextProperty().getValue());
+
+        // Expected result
+        SuggestionItem cs2103 = new SuggestionItemImpl(toCs2103.getStringRepresentation(), null);
+        SuggestionItem cs2103Week1Lecture = new SuggestionItemImpl(toCs2103Week1Lecture.getStringRepresentation(),
+                null);
+        SuggestionItem cs2103Week2 = new SuggestionItemImpl(toCs2103Week2.getStringRepresentation(), null);
+        SuggestionItem cs2103Week3 = new SuggestionItemImpl(toCs2103Week3.getStringRepresentation(), null);
+
+        List<SuggestionItem> expectedSuggestions = new ArrayList<>();
+        expectedSuggestions.add(cs2103);
+        expectedSuggestions.add(cs2103Week1Lecture);
+        expectedSuggestions.add(cs2103Week2);
+        expectedSuggestions.add(cs2103Week3);
+
+        List<SuggestionItem> suggestions = model.getSuggestions();
+
+        // check display text
+        for (int i = 0; i < expectedSuggestions.size(); i++) {
+            SuggestionItem suggestion = suggestions.get(i);
+            SuggestionItem expectedSuggestion = expectedSuggestions.get(i);
+            assertEquals(expectedSuggestion.getProperty("displayText"), suggestion.getProperty("displayText"));
+        }
+
+        List<String> expectedInputs = new ArrayList<>();
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103Week1Lecture.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103Week2.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103Week3.getStringRepresentation());
+
+        for (int i = 0; i < expectedInputs.size(); i++) {
+            SuggestionItem suggestionItem = suggestions.get(i);
+            String expectedInput = expectedInputs.get(i);
+            suggestionItem.getAction().run();
+            String input = model.getInput();
+            assertEquals(expectedInput, input);
+        }
+    }
+
+    @Test
+    public void parse_correctedPathWithPrefix_returnsDeleteSuggestionCommand() throws ParseException {
+        model.setInput("delete -t /CS2104");
+
+        SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(" -t /CS2104");
         assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
 
         commandCorrectPath.execute(model);
@@ -187,7 +239,9 @@ public class DeleteSuggestionCommandParserTest {
     }
 
     @Test
-    public void parse_correctedPath_returnsDeleteSuggestionCommand() throws ParseException {
+    public void parse_correctedPathWithoutPrefix_returnsDeleteSuggestionCommand() throws ParseException {
+        model.setInput("delete /CS2104");
+
         SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(" -t /CS2104");
         assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
 
@@ -218,10 +272,10 @@ public class DeleteSuggestionCommandParserTest {
         }
 
         List<String> expectedInputs = new ArrayList<>();
-        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103.getStringRepresentation());
-        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week1Lecture.getStringRepresentation());
-        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week2.getStringRepresentation());
-        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week3.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103Week1Lecture.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103Week2.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103Week3.getStringRepresentation());
 
         for (int i = 0; i < expectedInputs.size(); i++) {
             SuggestionItem suggestionItem = suggestions.get(i);

--- a/src/test/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParserTest.java
+++ b/src/test/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParserTest.java
@@ -84,15 +84,9 @@ public class DeleteSuggestionCommandParserTest {
     }
 
     @Test
-    public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(deleteSuggestionCommandParser, " /CS2103",
-            "Invalid input");
-
-        assertParseFailure(deleteSuggestionCommandParser, " /CS2 103",
-                "Invalid input");
-
-        assertParseFailure(deleteSuggestionCommandParser, " preamble -t /CS2103",
-            "Invalid input");
+    public void parse_emptyPath_throwsParseException() {
+        assertParseFailure(deleteSuggestionCommandParser, " ",
+            "Path cannot be empty");
     }
 
     @Test
@@ -101,8 +95,54 @@ public class DeleteSuggestionCommandParserTest {
     }
 
     @Test
-    public void parse_correctPath_returnsDeleteSuggestionCommand() throws ParseException {
+    public void parse_correctPathWithPrefix_returnsDeleteSuggestionCommand() throws ParseException {
         SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(" -t /CS2103");
+        assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
+
+        commandCorrectPath.execute(model);
+
+        assertEquals(Optional.of(RESPONSE_MESSAGE), model.responseTextProperty().getValue());
+
+        // Expected result
+        SuggestionItem cs2103 = new SuggestionItemImpl(toCs2103.getStringRepresentation(), null);
+        SuggestionItem cs2103Week1Lecture = new SuggestionItemImpl(toCs2103Week1Lecture.getStringRepresentation(),
+                null);
+        SuggestionItem cs2103Week2 = new SuggestionItemImpl(toCs2103Week2.getStringRepresentation(), null);
+        SuggestionItem cs2103Week3 = new SuggestionItemImpl(toCs2103Week3.getStringRepresentation(), null);
+
+        List<SuggestionItem> expectedSuggestions = new ArrayList<>();
+        expectedSuggestions.add(cs2103);
+        expectedSuggestions.add(cs2103Week1Lecture);
+        expectedSuggestions.add(cs2103Week2);
+        expectedSuggestions.add(cs2103Week3);
+
+        List<SuggestionItem> suggestions = model.getSuggestions();
+
+        // check display text
+        for (int i = 0; i < expectedSuggestions.size(); i++) {
+            SuggestionItem suggestion = suggestions.get(i);
+            SuggestionItem expectedSuggestion = expectedSuggestions.get(i);
+            assertEquals(expectedSuggestion.getProperty("displayText"), suggestion.getProperty("displayText"));
+        }
+
+        List<String> expectedInputs = new ArrayList<>();
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week1Lecture.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week2.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week3.getStringRepresentation());
+
+        for (int i = 0; i < expectedInputs.size(); i++) {
+            SuggestionItem suggestionItem = suggestions.get(i);
+            String expectedInput = expectedInputs.get(i);
+            suggestionItem.getAction().run();
+            String input = model.getInput();
+            assertEquals(expectedInput, input);
+        }
+    }
+
+    @Test
+    public void parse_correctPathWithoutPrefix_returnsDeleteSuggestionCommand() throws ParseException {
+        SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(" /CS2103");
         assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
 
         commandCorrectPath.execute(model);

--- a/src/test/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParserTest.java
+++ b/src/test/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParserTest.java
@@ -1,5 +1,6 @@
 package com.notably.logic.parser.suggestion;
 
+import static com.notably.logic.parser.CliSyntax.PREFIX_TITLE;
 import static com.notably.logic.parser.suggestion.SuggestionCommandParserTestUtil.assertParseFailure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -41,7 +42,6 @@ public class DeleteSuggestionCommandParserTest {
     private static DeleteSuggestionCommandParser deleteSuggestionCommandParser;
 
     private static final String COMMAND_WORD = "delete";
-    private static final String PREFIX_TITLE = "-t";
     private static final String RESPONSE_MESSAGE = "Delete a note";
 
     @BeforeAll
@@ -84,21 +84,31 @@ public class DeleteSuggestionCommandParserTest {
     }
 
     @Test
-    public void parse_emptyPath_throwsParseException() {
-        assertParseFailure(deleteSuggestionCommandParser, " ",
-            "Path cannot be empty");
+    public void parse_uncorrectedAbsolutePathWithPrefix_throwsParseException() {
+        assertParseFailure(deleteSuggestionCommandParser, " -t /RandomBlock", "Invalid path");
     }
 
     @Test
-    public void parse_uncorrectedPath_throwsParseException() {
+    public void parse_uncorrectedAbsolutePathWithoutPrefix_throwsParseException() {
+        assertParseFailure(deleteSuggestionCommandParser, " /RandomBlock", "Invalid path");
+    }
+
+    @Test
+    public void parse_uncorrectedRelativePathWithPrefix_throwsParseException() {
         assertParseFailure(deleteSuggestionCommandParser, " -t randomBlock", "Invalid path");
     }
 
     @Test
-    public void parse_correctPathWithPrefix_returnsDeleteSuggestionCommand() throws ParseException {
-        model.setInput("delete -t /CS2103");
+    public void parse_uncorrectedRelativePathWithoutPrefix_throwsParseException() {
+        assertParseFailure(deleteSuggestionCommandParser, " randomBlock", "Invalid path");
+    }
 
-        SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(" -t /CS2103");
+    @Test
+    public void parse_correctAbsolutePathWithPrefix_returnsDeleteSuggestionCommand() throws ParseException {
+        String arg = " " + PREFIX_TITLE + " " + toCs2103.getStringRepresentation();
+        model.setInput(COMMAND_WORD + arg);
+        SuggestionCommand commandCorrectPath =
+                deleteSuggestionCommandParser.parse(arg);
         assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
 
         commandCorrectPath.execute(model);
@@ -107,16 +117,18 @@ public class DeleteSuggestionCommandParserTest {
 
         // Expected result
         SuggestionItem cs2103 = new SuggestionItemImpl(toCs2103.getStringRepresentation(), null);
-        SuggestionItem cs2103Week1Lecture = new SuggestionItemImpl(toCs2103Week1Lecture.getStringRepresentation(),
-                null);
+        SuggestionItem cs2103Week1 = new SuggestionItemImpl(toCs2103Week1.getStringRepresentation(), null);
         SuggestionItem cs2103Week2 = new SuggestionItemImpl(toCs2103Week2.getStringRepresentation(), null);
         SuggestionItem cs2103Week3 = new SuggestionItemImpl(toCs2103Week3.getStringRepresentation(), null);
+        SuggestionItem cs2103Week1Lecture = new SuggestionItemImpl(toCs2103Week1Lecture.getStringRepresentation(),
+                null);
 
         List<SuggestionItem> expectedSuggestions = new ArrayList<>();
         expectedSuggestions.add(cs2103);
-        expectedSuggestions.add(cs2103Week1Lecture);
+        expectedSuggestions.add(cs2103Week1);
         expectedSuggestions.add(cs2103Week2);
         expectedSuggestions.add(cs2103Week3);
+        expectedSuggestions.add(cs2103Week1Lecture);
 
         List<SuggestionItem> suggestions = model.getSuggestions();
 
@@ -129,9 +141,10 @@ public class DeleteSuggestionCommandParserTest {
 
         List<String> expectedInputs = new ArrayList<>();
         expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103.getStringRepresentation());
-        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week1Lecture.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week1.getStringRepresentation());
         expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week2.getStringRepresentation());
         expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week3.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week1Lecture.getStringRepresentation());
 
         for (int i = 0; i < expectedInputs.size(); i++) {
             SuggestionItem suggestionItem = suggestions.get(i);
@@ -143,10 +156,11 @@ public class DeleteSuggestionCommandParserTest {
     }
 
     @Test
-    public void parse_correctPathWithoutPrefix_returnsDeleteSuggestionCommand() throws ParseException {
-        model.setInput("delete /CS2103");
-
-        SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(" /CS2103");
+    public void parse_correctAbsolutePathWithoutPrefix_returnsDeleteSuggestionCommand() throws ParseException {
+        String arg = " " + toCs2103.getStringRepresentation();
+        model.setInput(COMMAND_WORD + arg);
+        SuggestionCommand commandCorrectPath =
+                deleteSuggestionCommandParser.parse(arg);
         assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
 
         commandCorrectPath.execute(model);
@@ -155,6 +169,7 @@ public class DeleteSuggestionCommandParserTest {
 
         // Expected result
         SuggestionItem cs2103 = new SuggestionItemImpl(toCs2103.getStringRepresentation(), null);
+        SuggestionItem cs2103Week1 = new SuggestionItemImpl(toCs2103Week1.getStringRepresentation(), null);
         SuggestionItem cs2103Week1Lecture = new SuggestionItemImpl(toCs2103Week1Lecture.getStringRepresentation(),
                 null);
         SuggestionItem cs2103Week2 = new SuggestionItemImpl(toCs2103Week2.getStringRepresentation(), null);
@@ -162,9 +177,10 @@ public class DeleteSuggestionCommandParserTest {
 
         List<SuggestionItem> expectedSuggestions = new ArrayList<>();
         expectedSuggestions.add(cs2103);
-        expectedSuggestions.add(cs2103Week1Lecture);
+        expectedSuggestions.add(cs2103Week1);
         expectedSuggestions.add(cs2103Week2);
         expectedSuggestions.add(cs2103Week3);
+        expectedSuggestions.add(cs2103Week1Lecture);
 
         List<SuggestionItem> suggestions = model.getSuggestions();
 
@@ -177,9 +193,10 @@ public class DeleteSuggestionCommandParserTest {
 
         List<String> expectedInputs = new ArrayList<>();
         expectedInputs.add(COMMAND_WORD + " " + toCs2103.getStringRepresentation());
-        expectedInputs.add(COMMAND_WORD + " " + toCs2103Week1Lecture.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103Week1.getStringRepresentation());
         expectedInputs.add(COMMAND_WORD + " " + toCs2103Week2.getStringRepresentation());
         expectedInputs.add(COMMAND_WORD + " " + toCs2103Week3.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103Week1Lecture.getStringRepresentation());
 
         for (int i = 0; i < expectedInputs.size(); i++) {
             SuggestionItem suggestionItem = suggestions.get(i);
@@ -191,28 +208,31 @@ public class DeleteSuggestionCommandParserTest {
     }
 
     @Test
-    public void parse_correctedPathWithPrefix_returnsDeleteSuggestionCommand() throws ParseException {
-        model.setInput("delete -t /CS2104");
+    public void parse_correctedAbsolutePathWithPrefix_returnsDeleteSuggestionCommand() throws ParseException {
+        String arg = " " + PREFIX_TITLE + " /CS2104";
+        model.setInput(COMMAND_WORD + arg);
+        SuggestionCommand commandCorrectedPath =
+                deleteSuggestionCommandParser.parse(arg);
+        assertTrue(commandCorrectedPath instanceof DeleteSuggestionCommand);
 
-        SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(" -t /CS2104");
-        assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
-
-        commandCorrectPath.execute(model);
+        commandCorrectedPath.execute(model);
 
         assertEquals(Optional.of(RESPONSE_MESSAGE), model.responseTextProperty().getValue());
 
         // Expected result
         SuggestionItem cs2103 = new SuggestionItemImpl(toCs2103.getStringRepresentation(), null);
-        SuggestionItem cs2103Week1Lecture = new SuggestionItemImpl(toCs2103Week1Lecture.getStringRepresentation(),
-                null);
+        SuggestionItem cs2103Week1 = new SuggestionItemImpl(toCs2103Week1.getStringRepresentation(), null);
         SuggestionItem cs2103Week2 = new SuggestionItemImpl(toCs2103Week2.getStringRepresentation(), null);
         SuggestionItem cs2103Week3 = new SuggestionItemImpl(toCs2103Week3.getStringRepresentation(), null);
+        SuggestionItem cs2103Week1Lecture = new SuggestionItemImpl(toCs2103Week1Lecture.getStringRepresentation(),
+                null);
 
         List<SuggestionItem> expectedSuggestions = new ArrayList<>();
         expectedSuggestions.add(cs2103);
-        expectedSuggestions.add(cs2103Week1Lecture);
+        expectedSuggestions.add(cs2103Week1);
         expectedSuggestions.add(cs2103Week2);
         expectedSuggestions.add(cs2103Week3);
+        expectedSuggestions.add(cs2103Week1Lecture);
 
         List<SuggestionItem> suggestions = model.getSuggestions();
 
@@ -225,9 +245,10 @@ public class DeleteSuggestionCommandParserTest {
 
         List<String> expectedInputs = new ArrayList<>();
         expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103.getStringRepresentation());
-        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week1Lecture.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week1.getStringRepresentation());
         expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week2.getStringRepresentation());
         expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week3.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week1Lecture.getStringRepresentation());
 
         for (int i = 0; i < expectedInputs.size(); i++) {
             SuggestionItem suggestionItem = suggestions.get(i);
@@ -239,10 +260,10 @@ public class DeleteSuggestionCommandParserTest {
     }
 
     @Test
-    public void parse_correctedPathWithoutPrefix_returnsDeleteSuggestionCommand() throws ParseException {
-        model.setInput("delete /CS2104");
-
-        SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(" -t /CS2104");
+    public void parse_correctedAbsolutePathWithoutPrefix_returnsDeleteSuggestionCommand() throws ParseException {
+        String arg = " /CS2104";
+        model.setInput(COMMAND_WORD + arg);
+        SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(arg);
         assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
 
         commandCorrectPath.execute(model);
@@ -251,6 +272,7 @@ public class DeleteSuggestionCommandParserTest {
 
         // Expected result
         SuggestionItem cs2103 = new SuggestionItemImpl(toCs2103.getStringRepresentation(), null);
+        SuggestionItem cs2103Week1 = new SuggestionItemImpl(toCs2103Week1.getStringRepresentation(), null);
         SuggestionItem cs2103Week1Lecture = new SuggestionItemImpl(toCs2103Week1Lecture.getStringRepresentation(),
                 null);
         SuggestionItem cs2103Week2 = new SuggestionItemImpl(toCs2103Week2.getStringRepresentation(), null);
@@ -258,9 +280,10 @@ public class DeleteSuggestionCommandParserTest {
 
         List<SuggestionItem> expectedSuggestions = new ArrayList<>();
         expectedSuggestions.add(cs2103);
-        expectedSuggestions.add(cs2103Week1Lecture);
+        expectedSuggestions.add(cs2103Week1);
         expectedSuggestions.add(cs2103Week2);
         expectedSuggestions.add(cs2103Week3);
+        expectedSuggestions.add(cs2103Week1Lecture);
 
         List<SuggestionItem> suggestions = model.getSuggestions();
 
@@ -273,9 +296,172 @@ public class DeleteSuggestionCommandParserTest {
 
         List<String> expectedInputs = new ArrayList<>();
         expectedInputs.add(COMMAND_WORD + " " + toCs2103.getStringRepresentation());
-        expectedInputs.add(COMMAND_WORD + " " + toCs2103Week1Lecture.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103Week1.getStringRepresentation());
         expectedInputs.add(COMMAND_WORD + " " + toCs2103Week2.getStringRepresentation());
         expectedInputs.add(COMMAND_WORD + " " + toCs2103Week3.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103Week1Lecture.getStringRepresentation());
+
+        for (int i = 0; i < expectedInputs.size(); i++) {
+            SuggestionItem suggestionItem = suggestions.get(i);
+            String expectedInput = expectedInputs.get(i);
+            suggestionItem.getAction().run();
+            String input = model.getInput();
+            assertEquals(expectedInput, input);
+        }
+    }
+
+    @Test
+    public void parse_correctRelativePathWithPrefix_returnsDeleteSuggestionCommand() throws ParseException {
+        String arg = " -t Lecture";
+        model.setInput(COMMAND_WORD + arg);
+        SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(arg);
+        assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
+
+        commandCorrectPath.execute(model);
+
+        assertEquals(Optional.of(RESPONSE_MESSAGE), model.responseTextProperty().getValue());
+
+        //Expected result
+        SuggestionItem cs2103Week1Lecture = new SuggestionItemImpl(toCs2103Week1Lecture.getStringRepresentation(),
+                null);
+
+        List<SuggestionItem> expectedSuggestions = new ArrayList<>();
+
+        expectedSuggestions.add(cs2103Week1Lecture);
+
+        List<SuggestionItem> suggestions = model.getSuggestions();
+
+        // check display text
+        for (int i = 0; i < expectedSuggestions.size(); i++) {
+            SuggestionItem suggestion = suggestions.get(i);
+            SuggestionItem expectedSuggestion = expectedSuggestions.get(i);
+            assertEquals(expectedSuggestion.getProperty("displayText"), suggestion.getProperty("displayText"));
+        }
+
+        List<String> expectedInputs = new ArrayList<>();
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week1Lecture.getStringRepresentation());
+
+        for (int i = 0; i < expectedInputs.size(); i++) {
+            SuggestionItem suggestionItem = suggestions.get(i);
+            String expectedInput = expectedInputs.get(i);
+            suggestionItem.getAction().run();
+            String input = model.getInput();
+            assertEquals(expectedInput, input);
+        }
+    }
+
+    @Test
+    public void parse_correctRelativePathWithoutPrefix_returnsDeleteSuggestionCommand() throws ParseException {
+        String arg = " Lecture";
+        model.setInput(COMMAND_WORD + arg);
+        SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(arg);
+        assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
+
+        commandCorrectPath.execute(model);
+
+        assertEquals(Optional.of(RESPONSE_MESSAGE), model.responseTextProperty().getValue());
+
+        //Expected result
+        SuggestionItem cs2103Week1Lecture = new SuggestionItemImpl(toCs2103Week1Lecture.getStringRepresentation(),
+                null);
+
+        List<SuggestionItem> expectedSuggestions = new ArrayList<>();
+
+        expectedSuggestions.add(cs2103Week1Lecture);
+
+        List<SuggestionItem> suggestions = model.getSuggestions();
+
+        // check display text
+        for (int i = 0; i < expectedSuggestions.size(); i++) {
+            SuggestionItem suggestion = suggestions.get(i);
+            SuggestionItem expectedSuggestion = expectedSuggestions.get(i);
+            assertEquals(expectedSuggestion.getProperty("displayText"), suggestion.getProperty("displayText"));
+        }
+
+        List<String> expectedInputs = new ArrayList<>();
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103Week1Lecture.getStringRepresentation());
+
+        for (int i = 0; i < expectedInputs.size(); i++) {
+            SuggestionItem suggestionItem = suggestions.get(i);
+            String expectedInput = expectedInputs.get(i);
+            suggestionItem.getAction().run();
+            String input = model.getInput();
+            assertEquals(expectedInput, input);
+        }
+    }
+
+    @Test
+    public void parse_correctedRelativePathWithPrefix_returnsDeleteSuggestionCommand() throws ParseException {
+        String arg = " " + PREFIX_TITLE + " Lectre";
+        model.setInput(COMMAND_WORD + arg);
+        SuggestionCommand commandCorrectPath =
+                deleteSuggestionCommandParser.parse(arg);
+        assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
+
+        commandCorrectPath.execute(model);
+
+        assertEquals(Optional.of(RESPONSE_MESSAGE), model.responseTextProperty().getValue());
+
+        //Expected result
+        SuggestionItem cs2103Week1Lecture = new SuggestionItemImpl(toCs2103Week1Lecture.getStringRepresentation(),
+                null);
+
+        List<SuggestionItem> expectedSuggestions = new ArrayList<>();
+
+        expectedSuggestions.add(cs2103Week1Lecture);
+
+        List<SuggestionItem> suggestions = model.getSuggestions();
+
+        // check display text
+        for (int i = 0; i < expectedSuggestions.size(); i++) {
+            SuggestionItem suggestion = suggestions.get(i);
+            SuggestionItem expectedSuggestion = expectedSuggestions.get(i);
+            assertEquals(expectedSuggestion.getProperty("displayText"), suggestion.getProperty("displayText"));
+        }
+
+        List<String> expectedInputs = new ArrayList<>();
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week1Lecture.getStringRepresentation());
+
+        for (int i = 0; i < expectedInputs.size(); i++) {
+            SuggestionItem suggestionItem = suggestions.get(i);
+            String expectedInput = expectedInputs.get(i);
+            suggestionItem.getAction().run();
+            String input = model.getInput();
+            assertEquals(expectedInput, input);
+        }
+    }
+
+    @Test
+    public void parse_correctedRelativePathWithoutPrefix_returnsDeleteSuggestionCommand() throws ParseException {
+        String arg = " Lectre";
+        model.setInput(COMMAND_WORD + arg);
+        SuggestionCommand commandCorrectPath =
+                deleteSuggestionCommandParser.parse(arg);
+        assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
+
+        commandCorrectPath.execute(model);
+
+        assertEquals(Optional.of(RESPONSE_MESSAGE), model.responseTextProperty().getValue());
+
+        //Expected result
+        SuggestionItem cs2103Week1Lecture = new SuggestionItemImpl(toCs2103Week1Lecture.getStringRepresentation(),
+                null);
+
+        List<SuggestionItem> expectedSuggestions = new ArrayList<>();
+
+        expectedSuggestions.add(cs2103Week1Lecture);
+
+        List<SuggestionItem> suggestions = model.getSuggestions();
+
+        // check display text
+        for (int i = 0; i < expectedSuggestions.size(); i++) {
+            SuggestionItem suggestion = suggestions.get(i);
+            SuggestionItem expectedSuggestion = expectedSuggestions.get(i);
+            assertEquals(expectedSuggestion.getProperty("displayText"), suggestion.getProperty("displayText"));
+        }
+
+        List<String> expectedInputs = new ArrayList<>();
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103Week1Lecture.getStringRepresentation());
 
         for (int i = 0; i < expectedInputs.size(); i++) {
             SuggestionItem suggestionItem = suggestions.get(i);

--- a/src/test/java/com/notably/logic/suggestion/SuggestionEngineImplTest.java
+++ b/src/test/java/com/notably/logic/suggestion/SuggestionEngineImplTest.java
@@ -88,7 +88,7 @@ public class SuggestionEngineImplTest {
     }
 
     @Test
-    public void suggest_uncorrectedCommand_returnErrorSuggestionCommand() {
+    public void suggest_uncorrectedCommand_returnsErrorSuggestionCommand() {
         model.setInput("opensesame -t CS2103");
 
         // Expected result
@@ -97,7 +97,95 @@ public class SuggestionEngineImplTest {
     }
 
     @Test
-    public void suggest_correctedOpenCommandValidArgs_returnOpenSuggestionCommand() {
+    public void suggest_correctDeleteCommandValidArgs_returnsDeleteSuggestionCommand() {
+        model.setInput("delete -t Lecture");
+
+        // Test response text
+        String expectedResponseText = "Delete a note";
+        assertEquals(Optional.of(expectedResponseText), model.responseTextProperty().getValue());
+
+        // Expected result
+        List<SuggestionItem> expectedSuggestions = new ArrayList<>();
+        SuggestionItem cs2103Week1Lecture = new SuggestionItemImpl(toCs2103Week1Lecture.getStringRepresentation(),
+                null);
+        expectedSuggestions.add(cs2103Week1Lecture);
+
+        List<SuggestionItem> suggestions = model.getSuggestions();
+
+        for (int i = 0; i < expectedSuggestions.size(); i++) {
+            SuggestionItem suggestion = suggestions.get(i);
+            SuggestionItem expectedSuggestion = expectedSuggestions.get(i);
+            assertEquals(expectedSuggestion.getProperty("displayText"), suggestion.getProperty("displayText"));
+        }
+
+        List<String> expectedInputs = new ArrayList<>();
+        expectedInputs.add("delete -t " + toCs2103Week1Lecture.getStringRepresentation());
+
+        for (int i = 0; i < expectedInputs.size(); i++) {
+            SuggestionItem suggestionItem = suggestions.get(i);
+            String expectedInput = expectedInputs.get(i);
+            suggestionItem.getAction().run();
+            String input = model.getInput();
+            assertEquals(expectedInput, input);
+        }
+
+    }
+
+    @Test
+    public void suggest_correctDeleteCommandInvalidArgs_returnsErrorSuggestionCommand() {
+        model.setInput("delete CS2222");
+
+        // Expected result
+        String expectedResponseText = "Invalid path";
+        assertEquals(Optional.of(expectedResponseText), model.responseTextProperty().getValue());
+    }
+
+    @Test
+    public void suggest_correctedDeleteCommandValidArgs_returnsDeleteSuggestionCommand() {
+        model.setInput("dele -t Lecture");
+
+        // Test response text
+        String expectedResponseText = "Delete a note";
+        assertEquals(Optional.of(expectedResponseText), model.responseTextProperty().getValue());
+
+        // Expected result
+        List<SuggestionItem> expectedSuggestions = new ArrayList<>();
+        SuggestionItem cs2103Week1Lecture = new SuggestionItemImpl(toCs2103Week1Lecture.getStringRepresentation(),
+                null);
+        expectedSuggestions.add(cs2103Week1Lecture);
+
+        List<SuggestionItem> suggestions = model.getSuggestions();
+
+        for (int i = 0; i < expectedSuggestions.size(); i++) {
+            SuggestionItem suggestion = suggestions.get(i);
+            SuggestionItem expectedSuggestion = expectedSuggestions.get(i);
+            assertEquals(expectedSuggestion.getProperty("displayText"), suggestion.getProperty("displayText"));
+        }
+
+        List<String> expectedInputs = new ArrayList<>();
+        expectedInputs.add("dele -t " + toCs2103Week1Lecture.getStringRepresentation());
+
+        for (int i = 0; i < expectedInputs.size(); i++) {
+            SuggestionItem suggestionItem = suggestions.get(i);
+            String expectedInput = expectedInputs.get(i);
+            suggestionItem.getAction().run();
+            String input = model.getInput();
+            assertEquals(expectedInput, input);
+        }
+
+    }
+
+    @Test
+    public void suggest_correctedDeleteCommandInvalidArgs_returnsErrorSuggestionCommand() {
+        model.setInput("dele -t CS2222");
+
+        // Expected result
+        String expectedResponseText = "Invalid path";
+        assertEquals(Optional.of(expectedResponseText), model.responseTextProperty().getValue());
+    }
+
+    @Test
+    public void suggest_correctedOpenCommandValidArgs_returnsOpenSuggestionCommand() {
         model.setInput("oen -t Lecture");
 
         // Test response text
@@ -132,7 +220,7 @@ public class SuggestionEngineImplTest {
     }
 
     @Test
-    public void suggest_correctedOpenCommandInvalidArgs_returnErrorSuggestionCommand() {
+    public void suggest_correctedOpenCommandInvalidArgs_returnsErrorSuggestionCommand() {
         model.setInput("opn -t CS2222");
 
         // Expected result
@@ -141,7 +229,7 @@ public class SuggestionEngineImplTest {
     }
 
     @Test
-    public void suggest_correctedNewCommand_returnNewSuggestionCommand() {
+    public void suggest_correctedNewCommand_returnsNewSuggestionCommand() {
         model.setInput("nw -t NewNote");
 
         // Expected result
@@ -150,7 +238,7 @@ public class SuggestionEngineImplTest {
     }
 
     @Test
-    public void suggest_correctedEditCommand_returnEditSuggestionCommand() {
+    public void suggest_correctedEditCommand_returnsEditSuggestionCommand() {
         model.setInput("edt -t NewNote -b lorem ipsum");
 
         // Expected result
@@ -159,7 +247,7 @@ public class SuggestionEngineImplTest {
     }
 
     @Test
-    public void suggest_correctedHelpCommand_returnHelpSuggestionCommand() {
+    public void suggest_correctedHelpCommand_returnsHelpSuggestionCommand() {
         model.setInput("hAlp");
 
         // Expected result
@@ -168,7 +256,7 @@ public class SuggestionEngineImplTest {
     }
 
     @Test
-    public void suggest_correctedExitCommand_returnExitSuggestionCommand() {
+    public void suggest_correctedExitCommand_returnsExitSuggestionCommand() {
         model.setInput("ex");
 
         // Expected result


### PR DESCRIPTION
Closes #260 

These have similar implementation as `OpenSuggestionCommandParser` and `OpenSuggestionCommandParserTest`

- [x]  `DeleteSuggestionCommandParser` (update based on `OpenSuggestionCommandParser`
- [x] `DeleteSuggestionCommandParserTest` (after the `OpenSuggestionCommandParserTest` is approved)

NOTE: 
- will add more test cases for `OpenSuggestionCommand` in the `SuggestionEngineImplTest` to match `DeleteSuggestionCommand` test cases.
- will abstract out repetitive codes into a test util class
