### PR TITLE
Bind CommandBox to CommandInputModel [View]

### DIFF
--- a/src/main/java/com/notably/model/viewstate/ViewStateModelImpl.java
+++ b/src/main/java/com/notably/model/viewstate/ViewStateModelImpl.java
@@ -11,7 +11,7 @@ import javafx.beans.property.StringProperty;
  */
 public class ViewStateModelImpl implements ViewStateModel {
 
-    private final StringProperty input;
+    private StringProperty input;
     private final BooleanProperty helpOpen;
 
     public ViewStateModelImpl() {

--- a/src/main/java/com/notably/view/CommandBox.java
+++ b/src/main/java/com/notably/view/CommandBox.java
@@ -4,6 +4,7 @@ import com.notably.logic.commands.exceptions.CommandException;
 import com.notably.logic.parser.exceptions.ParseException;
 
 import javafx.application.Platform;
+import javafx.beans.property.StringProperty;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
@@ -22,12 +23,22 @@ public class CommandBox extends ViewPart<Region> {
     @FXML
     private TextField commandTextField;
 
-    public CommandBox(CommandExecutor commandExecutor) {
+    public CommandBox(CommandExecutor commandExecutor, StringProperty stringProperty) {
         super(FXML);
         this.commandExecutor = commandExecutor;
         Platform.runLater(() -> commandTextField.requestFocus());
+        initializeListeners(stringProperty);
+    }
+
+    /**
+     * Sets up weak and strong listeners for view-state management.
+     * @param stringProperty A property that, upon method execution, reflects the data that
+     * the user types in the model, and also reflects changes in the model to the text field.
+     */
+    private void initializeListeners(StringProperty stringProperty) {
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+        commandTextField.textProperty().bindBidirectional(stringProperty);
     }
 
     /**

--- a/src/main/java/com/notably/view/MainWindow.java
+++ b/src/main/java/com/notably/view/MainWindow.java
@@ -112,7 +112,7 @@ public class MainWindow extends ViewPart<Stage> {
         StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
-        CommandBox commandBox = new CommandBox(this::executeCommand);
+        CommandBox commandBox = new CommandBox(this::executeCommand, model.inputProperty());
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
 
         sidebarTreeView = new SideBarTreeView(model.getBlockTree(), model.currentlyOpenPathProperty());


### PR DESCRIPTION
It is necessary to create this binding as a precursor to "Implement Suggestions list" task in #245.

Note: Renaming of `View` components (e.g. `CommandBox` to `CommandInputView`) will be done after milestone 1.3, as part of View refactoring. 