### PR TITLE
Add shorthands in SuggestionCommand and SuggestionEngineImpl

### DIFF
--- a/src/main/java/com/notably/logic/commands/suggestion/DeleteSuggestionCommand.java
+++ b/src/main/java/com/notably/logic/commands/suggestion/DeleteSuggestionCommand.java
@@ -17,6 +17,7 @@ import com.notably.model.suggestion.SuggestionItemImpl;
 public class DeleteSuggestionCommand implements SuggestionCommand {
     public static final String COMMAND_WORD = "delete";
     private static final String RESPONSE_MESSAGE = "Delete a note";
+    private static final String COMMAND_SHORTHAND = "d";
 
     private AbsolutePath path;
     private String title;

--- a/src/main/java/com/notably/logic/commands/suggestion/DeleteSuggestionCommand.java
+++ b/src/main/java/com/notably/logic/commands/suggestion/DeleteSuggestionCommand.java
@@ -16,8 +16,9 @@ import com.notably.model.suggestion.SuggestionItemImpl;
  */
 public class DeleteSuggestionCommand implements SuggestionCommand {
     public static final String COMMAND_WORD = "delete";
+    public static final String COMMAND_SHORTHAND = "d";
+
     private static final String RESPONSE_MESSAGE = "Delete a note";
-    private static final String COMMAND_SHORTHAND = "d";
 
     private AbsolutePath path;
     private String title;

--- a/src/main/java/com/notably/logic/commands/suggestion/EditSuggestionCommand.java
+++ b/src/main/java/com/notably/logic/commands/suggestion/EditSuggestionCommand.java
@@ -10,6 +10,7 @@ import com.notably.model.Model;
 public class EditSuggestionCommand implements SuggestionCommand {
     public static final String COMMAND_WORD = "edit";
     private static final String RESPONSE_MESSAGE = "Edit a currently open note";
+    private static final String COMMAND_SHORTHAND = "e";
 
     @Override
     public void execute(Model model) {

--- a/src/main/java/com/notably/logic/commands/suggestion/EditSuggestionCommand.java
+++ b/src/main/java/com/notably/logic/commands/suggestion/EditSuggestionCommand.java
@@ -9,8 +9,9 @@ import com.notably.model.Model;
  */
 public class EditSuggestionCommand implements SuggestionCommand {
     public static final String COMMAND_WORD = "edit";
+    public static final String COMMAND_SHORTHAND = "e";
+
     private static final String RESPONSE_MESSAGE = "Edit a currently open note";
-    private static final String COMMAND_SHORTHAND = "e";
 
     @Override
     public void execute(Model model) {

--- a/src/main/java/com/notably/logic/commands/suggestion/HelpSuggestionCommand.java
+++ b/src/main/java/com/notably/logic/commands/suggestion/HelpSuggestionCommand.java
@@ -10,6 +10,7 @@ import com.notably.model.Model;
 public class HelpSuggestionCommand implements SuggestionCommand {
     public static final String COMMAND_WORD = "help";
     private static final String RESPONSE_MESSAGE = "Display a list of available commands";
+    private static final String COMMAND_SHORTHAND = "h";
 
     @Override
     public void execute(Model model) {

--- a/src/main/java/com/notably/logic/commands/suggestion/HelpSuggestionCommand.java
+++ b/src/main/java/com/notably/logic/commands/suggestion/HelpSuggestionCommand.java
@@ -9,8 +9,9 @@ import com.notably.model.Model;
  */
 public class HelpSuggestionCommand implements SuggestionCommand {
     public static final String COMMAND_WORD = "help";
+    public static final String COMMAND_SHORTHAND = "h";
+
     private static final String RESPONSE_MESSAGE = "Display a list of available commands";
-    private static final String COMMAND_SHORTHAND = "h";
 
     @Override
     public void execute(Model model) {

--- a/src/main/java/com/notably/logic/commands/suggestion/NewSuggestionCommand.java
+++ b/src/main/java/com/notably/logic/commands/suggestion/NewSuggestionCommand.java
@@ -9,8 +9,9 @@ import com.notably.model.Model;
  */
 public class NewSuggestionCommand implements SuggestionCommand {
     public static final String COMMAND_WORD = "new";
+    public static final String COMMAND_SHORTHAND = "n";
+
     private static final String RESPONSE_MESSAGE = "Create a new note";
-    private static final String COMMAND_SHORTHAND = "n";
 
     @Override
     public void execute(Model model) {

--- a/src/main/java/com/notably/logic/commands/suggestion/NewSuggestionCommand.java
+++ b/src/main/java/com/notably/logic/commands/suggestion/NewSuggestionCommand.java
@@ -10,6 +10,7 @@ import com.notably.model.Model;
 public class NewSuggestionCommand implements SuggestionCommand {
     public static final String COMMAND_WORD = "new";
     private static final String RESPONSE_MESSAGE = "Create a new note";
+    private static final String COMMAND_SHORTHAND = "n";
 
     @Override
     public void execute(Model model) {

--- a/src/main/java/com/notably/logic/commands/suggestion/OpenSuggestionCommand.java
+++ b/src/main/java/com/notably/logic/commands/suggestion/OpenSuggestionCommand.java
@@ -17,6 +17,7 @@ import com.notably.model.suggestion.SuggestionItemImpl;
 public class OpenSuggestionCommand implements SuggestionCommand {
     public static final String COMMAND_WORD = "open";
     private static final String RESPONSE_MESSAGE = "Open a note";
+    private static final String COMMAND_SHORTHAND = "o";
 
     private AbsolutePath path;
     private String title;

--- a/src/main/java/com/notably/logic/commands/suggestion/OpenSuggestionCommand.java
+++ b/src/main/java/com/notably/logic/commands/suggestion/OpenSuggestionCommand.java
@@ -16,8 +16,9 @@ import com.notably.model.suggestion.SuggestionItemImpl;
  */
 public class OpenSuggestionCommand implements SuggestionCommand {
     public static final String COMMAND_WORD = "open";
+    public static final String COMMAND_SHORTHAND = "o";
+
     private static final String RESPONSE_MESSAGE = "Open a note";
-    private static final String COMMAND_SHORTHAND = "o";
 
     private AbsolutePath path;
     private String title;

--- a/src/main/java/com/notably/logic/commands/suggestion/SearchSuggestionCommand.java
+++ b/src/main/java/com/notably/logic/commands/suggestion/SearchSuggestionCommand.java
@@ -21,6 +21,7 @@ import com.notably.model.suggestion.SuggestionItemImpl;
 public class SearchSuggestionCommand implements SuggestionCommand {
     public static final String COMMAND_WORD = "search";
     private static final String RESPONSE_MESSAGE = "Search through all notes based on keyword";
+    private static final String COMMAND_SHORTHAND = "s";
 
     private String keyword;
 

--- a/src/main/java/com/notably/logic/commands/suggestion/SearchSuggestionCommand.java
+++ b/src/main/java/com/notably/logic/commands/suggestion/SearchSuggestionCommand.java
@@ -20,8 +20,9 @@ import com.notably.model.suggestion.SuggestionItemImpl;
  */
 public class SearchSuggestionCommand implements SuggestionCommand {
     public static final String COMMAND_WORD = "search";
+    public static final String COMMAND_SHORTHAND = "s";
+
     private static final String RESPONSE_MESSAGE = "Search through all notes based on keyword";
-    private static final String COMMAND_SHORTHAND = "s";
 
     private String keyword;
 

--- a/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
@@ -38,12 +38,17 @@ public class DeleteSuggestionCommandParser implements SuggestionCommandParser<De
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(userInput, PREFIX_TITLE);
 
+        String title;
         if (!ParserUtil.arePrefixesPresent(argMultimap, PREFIX_TITLE)
                 || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format("Invalid input"));
+            title = userInput.trim();
+            if (title.isEmpty()) {
+                throw new ParseException("Path cannot be empty");
+            }
+        } else {
+            title = argMultimap.getValue(PREFIX_TITLE).get();
         }
 
-        String title = argMultimap.getValue(PREFIX_TITLE).get();
         AbsolutePath uncorrectedPath = ParserUtil.createAbsolutePath(title, model.getCurrentlyOpenPath());
         Optional<AbsolutePath> correctedPath = correctionEngine.correct(uncorrectedPath).getCorrectedItem();
 

--- a/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
@@ -1,0 +1,56 @@
+package com.notably.logic.parser.suggestion;
+
+import static com.notably.logic.parser.CliSyntax.PREFIX_TITLE;
+
+import java.util.Optional;
+
+import com.notably.commons.path.AbsolutePath;
+import com.notably.logic.commands.suggestion.DeleteSuggestionCommand;
+import com.notably.logic.correction.AbsolutePathCorrectionEngine;
+import com.notably.logic.parser.ArgumentMultimap;
+import com.notably.logic.parser.ArgumentTokenizer;
+import com.notably.logic.parser.ParserUtil;
+import com.notably.logic.parser.exceptions.ParseException;
+import com.notably.model.Model;
+
+/**
+ * Represents a Parser for DeleteSuggestionCommand.
+ */
+public class DeleteSuggestionCommandParser implements SuggestionCommandParser<DeleteSuggestionCommand> {
+    private static final int DISTANCE_THRESHOLD = 2;
+
+    private Model model;
+    private AbsolutePathCorrectionEngine correctionEngine;
+
+    public DeleteSuggestionCommandParser(Model model) {
+        this.model = model;
+        this.correctionEngine = new AbsolutePathCorrectionEngine(model, DISTANCE_THRESHOLD);
+    }
+
+    /**
+     * Parses user input in the context of the DeleteSuggestionCommand.
+     * @param userInput The user's input.
+     * @return A DeleteSuggestionCommand object with a corrected absolute path.
+     * @throws ParseException if the user input path cannot be found.
+     */
+    @Override
+    public DeleteSuggestionCommand parse(String userInput) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(userInput, PREFIX_TITLE);
+
+        if (!ParserUtil.arePrefixesPresent(argMultimap, PREFIX_TITLE)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format("Invalid input"));
+        }
+
+        String titles = argMultimap.getValue(PREFIX_TITLE).get();
+        AbsolutePath uncorrectedPath = ParserUtil.createAbsolutePath(titles, model.getCurrentlyOpenPath());
+        Optional<AbsolutePath> correctedPath = correctionEngine.correct(uncorrectedPath).getCorrectedItem();
+
+        if (correctedPath.equals(Optional.empty())) {
+            throw new ParseException("Invalid path");
+        }
+
+        return new DeleteSuggestionCommand(correctedPath.get());
+    }
+}

--- a/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
@@ -43,14 +43,12 @@ public class DeleteSuggestionCommandParser implements SuggestionCommandParser<De
             throw new ParseException(String.format("Invalid input"));
         }
 
-        String titles = argMultimap.getValue(PREFIX_TITLE).get();
-        AbsolutePath uncorrectedPath = ParserUtil.createAbsolutePath(titles, model.getCurrentlyOpenPath());
+        String title = argMultimap.getValue(PREFIX_TITLE).get();
+        AbsolutePath uncorrectedPath = ParserUtil.createAbsolutePath(title, model.getCurrentlyOpenPath());
         Optional<AbsolutePath> correctedPath = correctionEngine.correct(uncorrectedPath).getCorrectedItem();
 
-        if (correctedPath.equals(Optional.empty())) {
-            throw new ParseException("Invalid path");
-        }
-
-        return new DeleteSuggestionCommand(correctedPath.get());
+        return correctedPath
+                .map(DeleteSuggestionCommand::new)
+                .orElseThrow(() -> new ParseException("Invalid path"));
     }
 }

--- a/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
@@ -31,7 +31,7 @@ public class DeleteSuggestionCommandParser implements SuggestionCommandParser<De
      * Parses user input in the context of the DeleteSuggestionCommand.
      * @param userInput The user's input.
      * @return A DeleteSuggestionCommand object with a corrected absolute path.
-     * @throws ParseException if the user input path cannot be found.
+     * @throws ParseException if the user input is in a wrong format and/ or path cannot be found.
      */
     @Override
     public DeleteSuggestionCommand parse(String userInput) throws ParseException {

--- a/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
@@ -53,7 +53,7 @@ public class DeleteSuggestionCommandParser implements SuggestionCommandParser<De
         Optional<AbsolutePath> correctedPath = correctionEngine.correct(uncorrectedPath).getCorrectedItem();
 
         return correctedPath
-                .map(DeleteSuggestionCommand::new)
+                .map((AbsolutePath path) -> new DeleteSuggestionCommand(path, title))
                 .orElseThrow(() -> new ParseException("Invalid path"));
     }
 }

--- a/src/main/java/com/notably/logic/parser/suggestion/SearchSuggestionCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/suggestion/SearchSuggestionCommandParser.java
@@ -23,9 +23,13 @@ public class SearchSuggestionCommandParser implements SuggestionCommandParser<Se
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(userInput, PREFIX_SEARCH);
 
+        String title;
         if (!ParserUtil.arePrefixesPresent(argMultimap, PREFIX_SEARCH)
                 || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format("Invalid input"));
+            title = userInput.trim();
+            if (title.isEmpty()) {
+                throw new ParseException("Keyword cannot be empty");
+            }
         }
 
         return new SearchSuggestionCommand(userInput);

--- a/src/main/java/com/notably/logic/parser/suggestion/SearchSuggestionCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/suggestion/SearchSuggestionCommandParser.java
@@ -1,0 +1,33 @@
+package com.notably.logic.parser.suggestion;
+
+import static com.notably.logic.parser.CliSyntax.PREFIX_SEARCH;
+
+import com.notably.logic.commands.suggestion.SearchSuggestionCommand;
+import com.notably.logic.parser.ArgumentMultimap;
+import com.notably.logic.parser.ArgumentTokenizer;
+import com.notably.logic.parser.ParserUtil;
+import com.notably.logic.parser.exceptions.ParseException;
+
+/**
+ * Represents a Parser for SearchSuggestionCommand.
+ */
+public class SearchSuggestionCommandParser implements SuggestionCommandParser<SearchSuggestionCommand> {
+    /**
+     * Parses user input in the context of the SearchSuggestionCommand.
+     * @param userInput The user's input.
+     * @return A SearchSuggestionCommand object with a corrected absolute path.
+     * @throws ParseException if the user input is in a wrong format.
+     */
+    @Override
+    public SearchSuggestionCommand parse(String userInput) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(userInput, PREFIX_SEARCH);
+
+        if (!ParserUtil.arePrefixesPresent(argMultimap, PREFIX_SEARCH)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format("Invalid input"));
+        }
+
+        return new SearchSuggestionCommand(userInput);
+    }
+}

--- a/src/main/java/com/notably/logic/suggestion/SuggestionEngineImpl.java
+++ b/src/main/java/com/notably/logic/suggestion/SuggestionEngineImpl.java
@@ -5,16 +5,20 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.notably.logic.commands.suggestion.DeleteSuggestionCommand;
 import com.notably.logic.commands.suggestion.EditSuggestionCommand;
 import com.notably.logic.commands.suggestion.ErrorSuggestionCommand;
 import com.notably.logic.commands.suggestion.ExitSuggestionCommand;
 import com.notably.logic.commands.suggestion.HelpSuggestionCommand;
 import com.notably.logic.commands.suggestion.NewSuggestionCommand;
 import com.notably.logic.commands.suggestion.OpenSuggestionCommand;
+import com.notably.logic.commands.suggestion.SearchSuggestionCommand;
 import com.notably.logic.commands.suggestion.SuggestionCommand;
 import com.notably.logic.correction.StringCorrectionEngine;
 import com.notably.logic.parser.exceptions.ParseException;
+import com.notably.logic.parser.suggestion.DeleteSuggestionCommandParser;
 import com.notably.logic.parser.suggestion.OpenSuggestionCommandParser;
+import com.notably.logic.parser.suggestion.SearchSuggestionCommandParser;
 import com.notably.model.Model;
 
 import javafx.beans.property.StringProperty;
@@ -56,36 +60,53 @@ public class SuggestionEngineImpl implements SuggestionEngine {
         }
 
         String commandWord = matcher.group("commandWord");
-        Optional<String> correctedCommand = correctionEngine.correct(commandWord).getCorrectedItem();
-        if (correctedCommand.equals(Optional.empty())) {
-            return new ErrorSuggestionCommand(
+
+        if (commandWord.length() > 1) {
+            Optional<String> correctedCommand = correctionEngine.correct(commandWord).getCorrectedItem();
+            if (correctedCommand.equals(Optional.empty())) {
+                return new ErrorSuggestionCommand(
                     "Invalid command. To see the list of available commands, type: help");
+            }
+            commandWord = correctedCommand.get();
         }
 
-        commandWord = correctedCommand.get();
         final String arguments = matcher.group("arguments");
 
         switch (commandWord) {
         case OpenSuggestionCommand.COMMAND_WORD:
+        case OpenSuggestionCommand.COMMAND_SHORTHAND:
             try {
                 return new OpenSuggestionCommandParser(model).parse(arguments);
             } catch (ParseException e) {
                 return new ErrorSuggestionCommand(e.getMessage());
             }
 
-        /*case DeleteSuggestionCommand.COMMAND_WORD:
-            return new DeleteSuggestionCommandParser(model).parse(arguments);
+        case DeleteSuggestionCommand.COMMAND_WORD:
+        case DeleteSuggestionCommand.COMMAND_SHORTHAND:
+            try {
+                return new DeleteSuggestionCommandParser(model).parse(arguments);
+            } catch (ParseException e) {
+                return new ErrorSuggestionCommand(e.getMessage());
+            }
 
         case SearchSuggestionCommand.COMMAND_WORD:
-            return new SearchSuggestionCommandParser(model).parse(arguments);*/
+        case SearchSuggestionCommand.COMMAND_SHORTHAND:
+            try {
+                return new SearchSuggestionCommandParser().parse(arguments);
+            } catch (ParseException e) {
+                return new ErrorSuggestionCommand(e.getMessage());
+            }
 
         case NewSuggestionCommand.COMMAND_WORD:
+        case NewSuggestionCommand.COMMAND_SHORTHAND:
             return new NewSuggestionCommand();
 
         case EditSuggestionCommand.COMMAND_WORD:
+        case EditSuggestionCommand.COMMAND_SHORTHAND:
             return new EditSuggestionCommand();
 
         case HelpSuggestionCommand.COMMAND_WORD:
+        case HelpSuggestionCommand.COMMAND_SHORTHAND:
             return new HelpSuggestionCommand();
 
         case ExitSuggestionCommand.COMMAND_WORD:

--- a/src/test/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParserTest.java
+++ b/src/test/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParserTest.java
@@ -1,0 +1,194 @@
+package com.notably.logic.parser.suggestion;
+
+import static com.notably.logic.parser.suggestion.SuggestionCommandParserTestUtil.assertParseFailure;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.notably.commons.path.AbsolutePath;
+import com.notably.logic.commands.suggestion.DeleteSuggestionCommand;
+import com.notably.logic.commands.suggestion.SuggestionCommand;
+import com.notably.logic.parser.exceptions.ParseException;
+import com.notably.model.Model;
+import com.notably.model.ModelManager;
+import com.notably.model.block.Block;
+import com.notably.model.block.BlockImpl;
+import com.notably.model.block.BlockModel;
+import com.notably.model.block.BlockModelImpl;
+import com.notably.model.block.Title;
+import com.notably.model.suggestion.SuggestionItem;
+import com.notably.model.suggestion.SuggestionItemImpl;
+import com.notably.model.suggestion.SuggestionModel;
+import com.notably.model.suggestion.SuggestionModelImpl;
+import com.notably.model.viewstate.ViewStateModel;
+import com.notably.model.viewstate.ViewStateModelImpl;
+
+public class DeleteSuggestionCommandParserTest {
+    private static AbsolutePath toRoot;
+    private static AbsolutePath toCs2103;
+    private static AbsolutePath toCs3230;
+    private static AbsolutePath toCs2103Week1;
+    private static AbsolutePath toCs2103Week2;
+    private static AbsolutePath toCs2103Week3;
+    private static AbsolutePath toCs2103Week1Lecture;
+    private static Model model;
+    private static DeleteSuggestionCommandParser deleteSuggestionCommandParser;
+
+    private static final String COMMAND_WORD = "delete";
+    private static final String PREFIX_TITLE = "-t";
+    private static final String RESPONSE_MESSAGE = "Delete a note";
+
+    @BeforeAll
+    public static void setUp() {
+        // Set up paths
+        toRoot = AbsolutePath.fromString("/");
+        toCs2103 = AbsolutePath.fromString("/CS2103");
+        toCs3230 = AbsolutePath.fromString("/CS3230");
+        toCs2103Week1 = AbsolutePath.fromString("/CS2103/Week1");
+        toCs2103Week2 = AbsolutePath.fromString("/CS2103/Week2");
+        toCs2103Week3 = AbsolutePath.fromString("/CS2103/Week3");
+        toCs2103Week1Lecture = AbsolutePath.fromString("/CS2103/Week1/Lecture");
+
+        // Set up model
+        BlockModel blockModel = new BlockModelImpl();
+        SuggestionModel suggestionModel = new SuggestionModelImpl();
+        ViewStateModel viewStateModel = new ViewStateModelImpl();
+        model = new ModelManager(blockModel, suggestionModel, viewStateModel);
+
+        // Add test data to model
+        Block cs2103 = new BlockImpl(new Title("CS2103"));
+        Block cs3230 = new BlockImpl(new Title("CS3230"));
+        model.addBlockToCurrentPath(cs2103);
+        model.addBlockToCurrentPath(cs3230);
+
+        Block week1 = new BlockImpl(new Title("Week1"));
+        Block week2 = new BlockImpl(new Title("Week2"));
+        Block week3 = new BlockImpl(new Title("Week3"));
+        model.setCurrentlyOpenBlock(toCs2103);
+        model.addBlockToCurrentPath(week1);
+        model.addBlockToCurrentPath(week2);
+        model.addBlockToCurrentPath(week3);
+
+        Block lecture = new BlockImpl(new Title("Lecture"));
+        model.setCurrentlyOpenBlock(toCs2103Week1);
+        model.addBlockToCurrentPath(lecture);
+
+        // initialize parser
+        deleteSuggestionCommandParser = new DeleteSuggestionCommandParser(model);
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(deleteSuggestionCommandParser, " /CS2103",
+            "Invalid input");
+
+        assertParseFailure(deleteSuggestionCommandParser, " /CS2 103",
+                "Invalid input");
+
+        assertParseFailure(deleteSuggestionCommandParser, " preamble -t /CS2103",
+            "Invalid input");
+    }
+
+    @Test
+    public void parse_uncorrectedPath_throwsParseException() {
+        assertParseFailure(deleteSuggestionCommandParser, " -t randomBlock", "Invalid path");
+    }
+
+    @Test
+    public void parse_correctPath_returnsDeleteSuggestionCommand() throws ParseException {
+        SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(" -t /CS2103");
+        assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
+
+        commandCorrectPath.execute(model);
+
+        assertEquals(Optional.of(RESPONSE_MESSAGE), model.responseTextProperty().getValue());
+
+        // Expected result
+        SuggestionItem cs2103 = new SuggestionItemImpl(toCs2103.getStringRepresentation(), null);
+        SuggestionItem cs2103Week1Lecture = new SuggestionItemImpl(toCs2103Week1Lecture.getStringRepresentation(),
+                null);
+        SuggestionItem cs2103Week2 = new SuggestionItemImpl(toCs2103Week2.getStringRepresentation(), null);
+        SuggestionItem cs2103Week3 = new SuggestionItemImpl(toCs2103Week3.getStringRepresentation(), null);
+
+        List<SuggestionItem> expectedSuggestions = new ArrayList<>();
+        expectedSuggestions.add(cs2103);
+        expectedSuggestions.add(cs2103Week1Lecture);
+        expectedSuggestions.add(cs2103Week2);
+        expectedSuggestions.add(cs2103Week3);
+
+        List<SuggestionItem> suggestions = model.getSuggestions();
+
+        // check display text
+        for (int i = 0; i < expectedSuggestions.size(); i++) {
+            SuggestionItem suggestion = suggestions.get(i);
+            SuggestionItem expectedSuggestion = expectedSuggestions.get(i);
+            assertEquals(expectedSuggestion.getProperty("displayText"), suggestion.getProperty("displayText"));
+        }
+
+        List<String> expectedInputs = new ArrayList<>();
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week1Lecture.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week2.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week3.getStringRepresentation());
+
+        for (int i = 0; i < expectedInputs.size(); i++) {
+            SuggestionItem suggestionItem = suggestions.get(i);
+            String expectedInput = expectedInputs.get(i);
+            suggestionItem.getAction().run();
+            String input = model.getInput();
+            assertEquals(expectedInput, input);
+        }
+    }
+
+    @Test
+    public void parse_correctedPath_returnsDeleteSuggestionCommand() throws ParseException {
+        SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(" -t /CS2104");
+        assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
+
+        commandCorrectPath.execute(model);
+
+        assertEquals(Optional.of(RESPONSE_MESSAGE), model.responseTextProperty().getValue());
+
+        // Expected result
+        SuggestionItem cs2103 = new SuggestionItemImpl(toCs2103.getStringRepresentation(), null);
+        SuggestionItem cs2103Week1Lecture = new SuggestionItemImpl(toCs2103Week1Lecture.getStringRepresentation(),
+                null);
+        SuggestionItem cs2103Week2 = new SuggestionItemImpl(toCs2103Week2.getStringRepresentation(), null);
+        SuggestionItem cs2103Week3 = new SuggestionItemImpl(toCs2103Week3.getStringRepresentation(), null);
+
+        List<SuggestionItem> expectedSuggestions = new ArrayList<>();
+        expectedSuggestions.add(cs2103);
+        expectedSuggestions.add(cs2103Week1Lecture);
+        expectedSuggestions.add(cs2103Week2);
+        expectedSuggestions.add(cs2103Week3);
+
+        List<SuggestionItem> suggestions = model.getSuggestions();
+
+        // check display text
+        for (int i = 0; i < expectedSuggestions.size(); i++) {
+            SuggestionItem suggestion = suggestions.get(i);
+            SuggestionItem expectedSuggestion = expectedSuggestions.get(i);
+            assertEquals(expectedSuggestion.getProperty("displayText"), suggestion.getProperty("displayText"));
+        }
+
+        List<String> expectedInputs = new ArrayList<>();
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week1Lecture.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week2.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week3.getStringRepresentation());
+
+        for (int i = 0; i < expectedInputs.size(); i++) {
+            SuggestionItem suggestionItem = suggestions.get(i);
+            String expectedInput = expectedInputs.get(i);
+            suggestionItem.getAction().run();
+            String input = model.getInput();
+            assertEquals(expectedInput, input);
+        }
+    }
+}

--- a/src/test/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParserTest.java
+++ b/src/test/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParserTest.java
@@ -96,6 +96,8 @@ public class DeleteSuggestionCommandParserTest {
 
     @Test
     public void parse_correctPathWithPrefix_returnsDeleteSuggestionCommand() throws ParseException {
+        model.setInput("delete -t /CS2103");
+
         SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(" -t /CS2103");
         assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
 
@@ -142,7 +144,57 @@ public class DeleteSuggestionCommandParserTest {
 
     @Test
     public void parse_correctPathWithoutPrefix_returnsDeleteSuggestionCommand() throws ParseException {
+        model.setInput("delete /CS2103");
+
         SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(" /CS2103");
+        assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
+
+        commandCorrectPath.execute(model);
+
+        assertEquals(Optional.of(RESPONSE_MESSAGE), model.responseTextProperty().getValue());
+
+        // Expected result
+        SuggestionItem cs2103 = new SuggestionItemImpl(toCs2103.getStringRepresentation(), null);
+        SuggestionItem cs2103Week1Lecture = new SuggestionItemImpl(toCs2103Week1Lecture.getStringRepresentation(),
+                null);
+        SuggestionItem cs2103Week2 = new SuggestionItemImpl(toCs2103Week2.getStringRepresentation(), null);
+        SuggestionItem cs2103Week3 = new SuggestionItemImpl(toCs2103Week3.getStringRepresentation(), null);
+
+        List<SuggestionItem> expectedSuggestions = new ArrayList<>();
+        expectedSuggestions.add(cs2103);
+        expectedSuggestions.add(cs2103Week1Lecture);
+        expectedSuggestions.add(cs2103Week2);
+        expectedSuggestions.add(cs2103Week3);
+
+        List<SuggestionItem> suggestions = model.getSuggestions();
+
+        // check display text
+        for (int i = 0; i < expectedSuggestions.size(); i++) {
+            SuggestionItem suggestion = suggestions.get(i);
+            SuggestionItem expectedSuggestion = expectedSuggestions.get(i);
+            assertEquals(expectedSuggestion.getProperty("displayText"), suggestion.getProperty("displayText"));
+        }
+
+        List<String> expectedInputs = new ArrayList<>();
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103Week1Lecture.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103Week2.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103Week3.getStringRepresentation());
+
+        for (int i = 0; i < expectedInputs.size(); i++) {
+            SuggestionItem suggestionItem = suggestions.get(i);
+            String expectedInput = expectedInputs.get(i);
+            suggestionItem.getAction().run();
+            String input = model.getInput();
+            assertEquals(expectedInput, input);
+        }
+    }
+
+    @Test
+    public void parse_correctedPathWithPrefix_returnsDeleteSuggestionCommand() throws ParseException {
+        model.setInput("delete -t /CS2104");
+
+        SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(" -t /CS2104");
         assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
 
         commandCorrectPath.execute(model);
@@ -187,7 +239,9 @@ public class DeleteSuggestionCommandParserTest {
     }
 
     @Test
-    public void parse_correctedPath_returnsDeleteSuggestionCommand() throws ParseException {
+    public void parse_correctedPathWithoutPrefix_returnsDeleteSuggestionCommand() throws ParseException {
+        model.setInput("delete /CS2104");
+
         SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(" -t /CS2104");
         assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
 
@@ -218,10 +272,10 @@ public class DeleteSuggestionCommandParserTest {
         }
 
         List<String> expectedInputs = new ArrayList<>();
-        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103.getStringRepresentation());
-        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week1Lecture.getStringRepresentation());
-        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week2.getStringRepresentation());
-        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week3.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103Week1Lecture.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103Week2.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + toCs2103Week3.getStringRepresentation());
 
         for (int i = 0; i < expectedInputs.size(); i++) {
             SuggestionItem suggestionItem = suggestions.get(i);

--- a/src/test/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParserTest.java
+++ b/src/test/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParserTest.java
@@ -84,15 +84,9 @@ public class DeleteSuggestionCommandParserTest {
     }
 
     @Test
-    public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(deleteSuggestionCommandParser, " /CS2103",
-            "Invalid input");
-
-        assertParseFailure(deleteSuggestionCommandParser, " /CS2 103",
-                "Invalid input");
-
-        assertParseFailure(deleteSuggestionCommandParser, " preamble -t /CS2103",
-            "Invalid input");
+    public void parse_emptyPath_throwsParseException() {
+        assertParseFailure(deleteSuggestionCommandParser, " ",
+            "Path cannot be empty");
     }
 
     @Test
@@ -101,8 +95,54 @@ public class DeleteSuggestionCommandParserTest {
     }
 
     @Test
-    public void parse_correctPath_returnsDeleteSuggestionCommand() throws ParseException {
+    public void parse_correctPathWithPrefix_returnsDeleteSuggestionCommand() throws ParseException {
         SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(" -t /CS2103");
+        assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
+
+        commandCorrectPath.execute(model);
+
+        assertEquals(Optional.of(RESPONSE_MESSAGE), model.responseTextProperty().getValue());
+
+        // Expected result
+        SuggestionItem cs2103 = new SuggestionItemImpl(toCs2103.getStringRepresentation(), null);
+        SuggestionItem cs2103Week1Lecture = new SuggestionItemImpl(toCs2103Week1Lecture.getStringRepresentation(),
+                null);
+        SuggestionItem cs2103Week2 = new SuggestionItemImpl(toCs2103Week2.getStringRepresentation(), null);
+        SuggestionItem cs2103Week3 = new SuggestionItemImpl(toCs2103Week3.getStringRepresentation(), null);
+
+        List<SuggestionItem> expectedSuggestions = new ArrayList<>();
+        expectedSuggestions.add(cs2103);
+        expectedSuggestions.add(cs2103Week1Lecture);
+        expectedSuggestions.add(cs2103Week2);
+        expectedSuggestions.add(cs2103Week3);
+
+        List<SuggestionItem> suggestions = model.getSuggestions();
+
+        // check display text
+        for (int i = 0; i < expectedSuggestions.size(); i++) {
+            SuggestionItem suggestion = suggestions.get(i);
+            SuggestionItem expectedSuggestion = expectedSuggestions.get(i);
+            assertEquals(expectedSuggestion.getProperty("displayText"), suggestion.getProperty("displayText"));
+        }
+
+        List<String> expectedInputs = new ArrayList<>();
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week1Lecture.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week2.getStringRepresentation());
+        expectedInputs.add(COMMAND_WORD + " " + PREFIX_TITLE + " " + toCs2103Week3.getStringRepresentation());
+
+        for (int i = 0; i < expectedInputs.size(); i++) {
+            SuggestionItem suggestionItem = suggestions.get(i);
+            String expectedInput = expectedInputs.get(i);
+            suggestionItem.getAction().run();
+            String input = model.getInput();
+            assertEquals(expectedInput, input);
+        }
+    }
+
+    @Test
+    public void parse_correctPathWithoutPrefix_returnsDeleteSuggestionCommand() throws ParseException {
+        SuggestionCommand commandCorrectPath = deleteSuggestionCommandParser.parse(" /CS2103");
         assertTrue(commandCorrectPath instanceof DeleteSuggestionCommand);
 
         commandCorrectPath.execute(model);

--- a/src/test/java/com/notably/logic/parser/suggestion/SearchSuggestionCommandParserTest.java
+++ b/src/test/java/com/notably/logic/parser/suggestion/SearchSuggestionCommandParserTest.java
@@ -1,0 +1,154 @@
+package com.notably.logic.parser.suggestion;
+
+import static com.notably.logic.parser.suggestion.SuggestionCommandParserTestUtil.assertParseFailure;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.notably.commons.path.AbsolutePath;
+import com.notably.logic.commands.suggestion.SearchSuggestionCommand;
+import com.notably.logic.commands.suggestion.SuggestionCommand;
+import com.notably.logic.parser.exceptions.ParseException;
+import com.notably.model.Model;
+import com.notably.model.ModelManager;
+import com.notably.model.block.Block;
+import com.notably.model.block.BlockImpl;
+import com.notably.model.block.BlockModel;
+import com.notably.model.block.BlockModelImpl;
+import com.notably.model.block.Body;
+import com.notably.model.block.Title;
+import com.notably.model.suggestion.SuggestionItem;
+import com.notably.model.suggestion.SuggestionItemImpl;
+import com.notably.model.suggestion.SuggestionModel;
+import com.notably.model.suggestion.SuggestionModelImpl;
+import com.notably.model.viewstate.ViewStateModel;
+import com.notably.model.viewstate.ViewStateModelImpl;
+
+public class SearchSuggestionCommandParserTest {
+    private static AbsolutePath toRoot;
+    private static AbsolutePath toCs2103;
+    private static AbsolutePath toCs3230;
+    private static AbsolutePath toCs2103Week1;
+    private static AbsolutePath toCs2103Week2;
+    private static AbsolutePath toCs2103Week3;
+    private static AbsolutePath toCs2103Week1Lecture;
+    private static Model model;
+    private static Body toCs2103Week1LectureBody = new Body("Week 1 is ezpz. I am falling asleep.");
+    private static Body toCs2103Week2Body = new Body("I was wrong. This mod is so time consuming");
+    private static Body toCs2103Week3Body = new Body("Will I fail this mod?");
+    private static Body toCs3230Body = new Body("I confirm fail this mod. Fail lah fail lah.");
+    private static SearchSuggestionCommandParser searchSuggestionCommandParser;
+
+    private static final String COMMAND_WORD = "search";
+    private static final String RESPONSE_MESSAGE = "Search through all notes based on keyword";
+
+    @BeforeAll
+    public static void setUp() {
+        // Set up paths
+        toRoot = AbsolutePath.fromString("/");
+        toCs2103 = AbsolutePath.fromString("/CS2103");
+        toCs3230 = AbsolutePath.fromString("/CS3230");
+        toCs2103Week1 = AbsolutePath.fromString("/CS2103/Week1");
+        toCs2103Week2 = AbsolutePath.fromString("/CS2103/Week2");
+        toCs2103Week3 = AbsolutePath.fromString("/CS2103/Week3");
+        toCs2103Week1Lecture = AbsolutePath.fromString("/CS2103/Week1/Lecture");
+
+        // Set up model
+        BlockModel blockModel = new BlockModelImpl();
+        SuggestionModel suggestionModel = new SuggestionModelImpl();
+        ViewStateModel viewStateModel = new ViewStateModelImpl();
+        model = new ModelManager(blockModel, suggestionModel, viewStateModel);
+
+        // Add test data to model
+        Block cs2103 = new BlockImpl(new Title("CS2103"));
+        Block cs3230 = new BlockImpl(new Title("CS3230"), toCs3230Body);
+        model.addBlockToCurrentPath(cs2103);
+        model.addBlockToCurrentPath(cs3230);
+
+        Block week1 = new BlockImpl(new Title("Week1"));
+        Block week2 = new BlockImpl(new Title("Week2"), toCs2103Week2Body);
+        Block week3 = new BlockImpl(new Title("Week3"), toCs2103Week3Body);
+        model.setCurrentlyOpenBlock(toCs2103);
+        model.addBlockToCurrentPath(week1);
+        model.addBlockToCurrentPath(week2);
+        model.addBlockToCurrentPath(week3);
+
+        Block lecture = new BlockImpl(new Title("Lecture"), toCs2103Week1LectureBody);
+        model.setCurrentlyOpenBlock(toCs2103Week1);
+        model.addBlockToCurrentPath(lecture);
+
+        // initialize parser
+        searchSuggestionCommandParser = new SearchSuggestionCommandParser();
+    }
+
+    @Test
+    public void parse_emptyPath_throwsParseException() {
+        assertParseFailure(searchSuggestionCommandParser, " ",
+                "Keyword cannot be empty");
+    }
+
+    @Test
+    public void parse_keywordFound_returnsOpenCommand() throws ParseException {
+        SuggestionCommand command = searchSuggestionCommandParser.parse("fail");
+        assertTrue(command instanceof SearchSuggestionCommand);
+
+        command.execute(model);
+
+        // Test responseText
+        String expectedResponseText = "Search through all notes based on keyword";
+        assertEquals(Optional.of(expectedResponseText), model.responseTextProperty().getValue());
+
+        // Expected suggestions
+        List<SuggestionItem> expectedSuggestions = new ArrayList<>();
+        SuggestionItem suggestionItem = new SuggestionItemImpl(toCs3230.getStringRepresentation(), 3,
+                null);
+        SuggestionItem suggestionItem1 = new SuggestionItemImpl(toCs2103Week3.getStringRepresentation(), 1,
+                null);
+        expectedSuggestions.add(suggestionItem);
+        expectedSuggestions.add(suggestionItem1);
+
+        List<SuggestionItem> suggestions = model.getSuggestions();
+
+        // Test displayText and frequency
+        for (int i = 0; i < expectedSuggestions.size(); i++) {
+            SuggestionItem suggestion = suggestions.get(i);
+            SuggestionItem expectedSuggestion = expectedSuggestions.get(i);
+            assertEquals(expectedSuggestion.getProperty("displayText"), suggestion.getProperty("displayText"));
+            assertEquals(expectedSuggestion.getProperty("frequency"), suggestion.getProperty("frequency"));
+        }
+
+        // Expected currently open paths
+        List<AbsolutePath> expectedCurrentlyOpenPaths = new ArrayList<>();
+        expectedCurrentlyOpenPaths.add(toCs3230);
+        expectedCurrentlyOpenPaths.add(toCs2103Week3);
+
+        // Test Runnable action and check currentlyOpenPath
+        for (int i = 0; i < expectedCurrentlyOpenPaths.size(); i++) {
+            SuggestionItem suggestion = suggestions.get(i);
+            suggestion.getAction().run();
+
+            assertEquals(expectedCurrentlyOpenPaths.get(i), model.getCurrentlyOpenPath());
+        }
+    }
+
+    @Test
+    public void parse_keywordNotFound_returnsEmptyList() throws ParseException {
+        SuggestionCommand command = searchSuggestionCommandParser.parse("dayum");
+        assertTrue(command instanceof SearchSuggestionCommand);
+
+        command.execute(model);
+
+        // Test responseText
+        String expectedResponseText = "Search through all notes based on keyword";
+        assertEquals(Optional.of(expectedResponseText), model.responseTextProperty().getValue());
+
+        List<SuggestionItem> suggestions = model.getSuggestions();
+        assertTrue(suggestions.size() == 0);
+    }
+}


### PR DESCRIPTION
Closes #285 

This PR works on:
- [x] Add command shorthands in `SuggestionCommand` classes
- [x] Update `SuggestionEngineImpl` to consider shorthands
- [ ] Update `SuggestionEngineImplTest`