### PR TITLE
Fix path correction bug

### DIFF
--- a/src/main/java/com/notably/logic/correction/AbsolutePathCorrectionEngine.java
+++ b/src/main/java/com/notably/logic/correction/AbsolutePathCorrectionEngine.java
@@ -143,14 +143,17 @@ public class AbsolutePathCorrectionEngine implements CorrectionEngine<AbsolutePa
         int i = 0;
         int distance = 0;
         while (i < firstComponents.size() && i < secondComponents.size()) {
+            String firstComponent = firstComponents.get(i);  
+            String secondComponent = secondComponents.get(i);
+
             // Check for possible forward matching
             if (forwardMatch && i == firstComponents.size() - 1
-                    && secondComponents.get(i).startsWith(firstComponents.get(i))) {
+                    && secondComponent.toLowerCase().startsWith(firstComponent.toLowerCase())) {
                 i++;
                 continue;
             }
             if (forwardMatch && i == secondComponents.size() - 1
-                    && firstComponents.get(i).startsWith(secondComponents.get(i))) {
+                    && firstComponent.toLowerCase().startsWith(secondComponent.toLowerCase())) {
                 i++;
                 continue;
             }

--- a/src/main/java/com/notably/logic/correction/AbsolutePathCorrectionEngine.java
+++ b/src/main/java/com/notably/logic/correction/AbsolutePathCorrectionEngine.java
@@ -143,7 +143,7 @@ public class AbsolutePathCorrectionEngine implements CorrectionEngine<AbsolutePa
         int i = 0;
         int distance = 0;
         while (i < firstComponents.size() && i < secondComponents.size()) {
-            String firstComponent = firstComponents.get(i);  
+            String firstComponent = firstComponents.get(i);
             String secondComponent = secondComponents.get(i);
 
             // Check for possible forward matching

--- a/src/test/java/com/notably/logic/correction/AbsolutePathCorrectionEngineTest.java
+++ b/src/test/java/com/notably/logic/correction/AbsolutePathCorrectionEngineTest.java
@@ -120,7 +120,7 @@ public class AbsolutePathCorrectionEngineTest {
         final int distanceThreshold = 1;
         final AbsolutePathCorrectionEngine correctionEngine = new AbsolutePathCorrectionEngine(
                 model, distanceThreshold, true);
-        final AbsolutePath uncorrectedInput = AbsolutePath.fromString("/another/b");
+        final AbsolutePath uncorrectedInput = AbsolutePath.fromString("/another/BL");
 
         final AbsolutePath expectedCorrectedItem = toAnotherBlock;
         final CorrectionStatus expectedCorrectionStatus = CorrectionStatus.CORRECTED;

--- a/src/test/java/com/notably/logic/correction/AbsolutePathCorrectionEngineTest.java
+++ b/src/test/java/com/notably/logic/correction/AbsolutePathCorrectionEngineTest.java
@@ -120,6 +120,22 @@ public class AbsolutePathCorrectionEngineTest {
         final int distanceThreshold = 1;
         final AbsolutePathCorrectionEngine correctionEngine = new AbsolutePathCorrectionEngine(
                 model, distanceThreshold, true);
+        final AbsolutePath uncorrectedInput = AbsolutePath.fromString("/another/bl");
+
+        final AbsolutePath expectedCorrectedItem = toAnotherBlock;
+        final CorrectionStatus expectedCorrectionStatus = CorrectionStatus.CORRECTED;
+        final CorrectionResult<AbsolutePath> expectedCorrectionResult = new CorrectionResult<>(
+                expectedCorrectionStatus, expectedCorrectedItem);
+
+        CorrectionResult<AbsolutePath> correctionResult = correctionEngine.correct(uncorrectedInput);
+        assertEquals(expectedCorrectionResult, correctionResult);
+    }
+
+    @Test
+    public void correct_forwardMatchingDifferingCases() {
+        final int distanceThreshold = 1;
+        final AbsolutePathCorrectionEngine correctionEngine = new AbsolutePathCorrectionEngine(
+                model, distanceThreshold, true);
         final AbsolutePath uncorrectedInput = AbsolutePath.fromString("/another/BL");
 
         final AbsolutePath expectedCorrectedItem = toAnotherBlock;


### PR DESCRIPTION
In #321, I introduced the forward-matching feature. However, I missed out on the case when forward-matching has to be done on paths with differing cases.

For example, by design, "/another/BL" should forward-match with "/another/block". This PR introduces some changes that accommodate for this behavior.