### PR TITLE
Setup coverage reporting to codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk: openjdk11
 
 script: >-
   ./config/travis/run-checks.sh &&
-  ./gradlew clean checkstyleMain checkstyleTest test asciidoctor
+  ./gradlew clean checkstyleMain checkstyleTest test jacocoTestCoverage asciidoctor
 
 deploy:
   skip_cleanup: true
@@ -11,6 +11,9 @@ deploy:
   script: ./config/travis/deploy_github_pages.sh
   on:
     branch: master
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
 
 # Gradle-related files caching
 # See: https://docs.travis-ci.com/user/languages/java/#caching

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk: openjdk11
 
 script: >-
   ./config/travis/run-checks.sh &&
-  ./gradlew clean checkstyleMain checkstyleTest test jacocoTestCoverage asciidoctor
+  ./gradlew clean checkstyleMain checkstyleTest test jacocoTestReport asciidoctor
 
 deploy:
   skip_cleanup: true

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '4.0.4'
     id 'org.asciidoctor.convert' version '1.5.6'
     id 'application'
+    id 'jacoco'
 }
 
 // Specifies the entry point of the application

--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,13 @@ asciidoctor {
     }
 }
 
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        html.enabled false
+    }
+}
+
 // Copies stylesheets into the directory containing generated HTML files as
 // Asciidoctor does not copy linked CSS files to the output directory when rendering.
 // This is needed for linked stylesheets and embedded stylesheets which import other files.


### PR DESCRIPTION
Closes #384 

In this PR:
- [x] [Codecov](https://codecov.io/) integration is set up, so that it's easier for us to view whether our changes increased/decreased our parts' coverage (Perhaps it's a good idea to give [this](https://docs.codecov.io/docs/codecov-delta) a read! It explains about the reported parameters)