### PR TITLE
Implementation of EditCurrentBody in LogicManager.

### DIFF
--- a/src/main/java/com/notably/logic/Logic.java
+++ b/src/main/java/com/notably/logic/Logic.java
@@ -19,6 +19,12 @@ public interface Logic {
     void execute(String commandText) throws CommandException, ParseException;
 
     /**
+     * Edit the body of the current opened block.
+     * @param bodyContent The content of the body entered by the user.
+     */
+    void editCurrentBlockBody(String bodyContent);
+
+    /**
      * Gets the path of the block data file.
      */
     Path getBlockDataFilePath();

--- a/src/main/java/com/notably/logic/Logic.java
+++ b/src/main/java/com/notably/logic/Logic.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 
 import com.notably.commons.GuiSettings;
 import com.notably.logic.commands.exceptions.CommandException;
+import com.notably.logic.exceptions.EditBlockBodyException;
 import com.notably.logic.parser.exceptions.ParseException;
 
 /**
@@ -22,7 +23,7 @@ public interface Logic {
      * Edit the body of the current opened block.
      * @param bodyContent The content of the body entered by the user.
      */
-    void editCurrentBlockBody(String bodyContent);
+    void editCurrentBlockBody(String bodyContent) throws EditBlockBodyException;
 
     /**
      * Gets the path of the block data file.

--- a/src/main/java/com/notably/logic/LogicManager.java
+++ b/src/main/java/com/notably/logic/LogicManager.java
@@ -1,4 +1,5 @@
 package com.notably.logic;
+import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -14,6 +15,8 @@ import com.notably.logic.parser.exceptions.ParseException;
 import com.notably.logic.suggestion.SuggestionEngine;
 import com.notably.logic.suggestion.SuggestionEngineImpl;
 import com.notably.model.Model;
+import com.notably.model.block.Body;
+import com.notably.model.block.exceptions.CannotModifyRootException;
 import com.notably.storage.Storage;
 
 
@@ -50,6 +53,15 @@ public class LogicManager implements Logic {
         } catch (IOException ioe) {
             throw new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe);
         }
+    }
+
+    @Override
+    public void editCurrentBlockBody(String bodyContent) throws CannotModifyRootException {
+        requireNonNull(bodyContent);
+        Body body = new Body(bodyContent);
+
+        // Throws exception if current block is a Root.
+        model.updateCurrentlyOpenBlockBody(body);
     }
 
     @Override

--- a/src/main/java/com/notably/logic/LogicManager.java
+++ b/src/main/java/com/notably/logic/LogicManager.java
@@ -10,6 +10,7 @@ import com.notably.commons.GuiSettings;
 import com.notably.commons.LogsCenter;
 import com.notably.logic.commands.Command;
 import com.notably.logic.commands.exceptions.CommandException;
+import com.notably.logic.exceptions.EditBlockBodyException;
 import com.notably.logic.parser.NotablyParser;
 import com.notably.logic.parser.exceptions.ParseException;
 import com.notably.logic.suggestion.SuggestionEngine;
@@ -56,12 +57,16 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public void editCurrentBlockBody(String bodyContent) throws CannotModifyRootException {
+    public void editCurrentBlockBody(String bodyContent) throws EditBlockBodyException {
         requireNonNull(bodyContent);
         Body body = new Body(bodyContent);
 
         // Throws exception if current block is a Root.
-        model.updateCurrentlyOpenBlockBody(body);
+        try {
+            model.updateCurrentlyOpenBlockBody(body);
+        } catch(CannotModifyRootException ex) {
+            throw new EditBlockBodyException(ex.getMessage());
+        }
     }
 
     @Override

--- a/src/main/java/com/notably/logic/LogicManager.java
+++ b/src/main/java/com/notably/logic/LogicManager.java
@@ -64,7 +64,7 @@ public class LogicManager implements Logic {
         // Throws exception if current block is a Root.
         try {
             model.updateCurrentlyOpenBlockBody(body);
-        } catch(CannotModifyRootException ex) {
+        } catch (CannotModifyRootException ex) {
             throw new EditBlockBodyException(ex.getMessage());
         }
     }

--- a/src/main/java/com/notably/logic/exceptions/EditBlockBodyException.java
+++ b/src/main/java/com/notably/logic/exceptions/EditBlockBodyException.java
@@ -1,0 +1,11 @@
+package com.notably.logic.exceptions;
+
+/**
+ * Represents an error when editing current block body.
+ */
+public class EditBlockBodyException extends Exception {
+    public EditBlockBodyException(String message) {
+        super(message);
+    }
+
+}

--- a/src/test/java/com/notably/logic/LogicManagerTest.java
+++ b/src/test/java/com/notably/logic/LogicManagerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import com.notably.logic.commands.exceptions.CommandException;
 import com.notably.logic.parser.exceptions.ParseException;
 import com.notably.model.Model;
 import com.notably.model.ModelManager;
@@ -47,6 +48,18 @@ public class LogicManagerTest {
     public void execute_invalidCommandFormat_throwsParseException() {
         String invalidCommand = "uicfhmowqewca";
         assertThrows(ParseException.class, () -> logic.execute(invalidCommand));
+    }
+
+    @Test
+    public void execute_invalidCommand_throwsCommandException() {
+        String invalidCommand = "delete /";
+        assertThrows(CommandException.class, () -> logic.execute(invalidCommand));
+    }
+
+    @Test
+    public void () {
+        String invalidCommand = "delete /";
+        assertThrows(CommandException.class, () -> logic.execute(invalidCommand));
     }
 
 

--- a/src/test/java/com/notably/logic/LogicManagerTest.java
+++ b/src/test/java/com/notably/logic/LogicManagerTest.java
@@ -56,11 +56,4 @@ public class LogicManagerTest {
         assertThrows(CommandException.class, () -> logic.execute(invalidCommand));
     }
 
-    @Test
-    public void () {
-        String invalidCommand = "delete /";
-        assertThrows(CommandException.class, () -> logic.execute(invalidCommand));
-    }
-
-
 }

--- a/src/test/java/com/notably/logic/LogicManagerTest.java
+++ b/src/test/java/com/notably/logic/LogicManagerTest.java
@@ -1,150 +1,53 @@
-//TODO: To be enabled or changed when refactoring is completed
-//package com.notably.logic;
-//
-//import static com.notably.commons.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
-//import static com.notably.commons.Messages.MESSAGE_UNKNOWN_COMMAND;
-//import static com.notably.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
-//import static com.notably.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
-//import static com.notably.logic.commands.CommandTestUtil.NAME_DESC_AMY;
-//import static com.notably.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
-//import static com.notably.testutil.Assert.assertThrows;
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//
-//import java.io.IOException;
-//import java.nio.file.Path;
-//
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.io.TempDir;
-//
-//import com.notably.logic.commands.AddCommand;
-//import com.notably.logic.commands.CommandResult;
-//import com.notably.logic.commands.exceptions.CommandException;
-//import com.notably.logic.parser.exceptions.ParseException;
-//import com.notably.model.Model;
-//import com.notably.model.ModelManager;
-//import com.notably.model.ReadOnlyAddressBook;
-//import com.notably.model.UserPrefs;
-//import com.notably.storage.JsonAddressBookStorage;
-//import com.notably.storage.JsonUserPrefsStorage;
-//import com.notably.storage.StorageManager;
-//
-//public class LogicManagerTest {
-//    private static final IOException DUMMY_IO_EXCEPTION = new IOException("dummy exception");
-//
-//    @TempDir
-//    public Path temporaryFolder;
-//
-//    private Model model = new ModelManager();
-//    private Logic logic;
-//
-//    @BeforeEach
-//    public void setUp() {
-//        JsonAddressBookStorage addressBookStorage =
-//                new JsonAddressBookStorage(temporaryFolder.resolve("addressBook.json"));
-//        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
-//        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
-//        logic = new LogicManager(model, storage);
-//    }
-//
-//    @Test
-//    public void execute_invalidCommandFormat_throwsParseException() {
-//        String invalidCommand = "uicfhmowqewca";
-//        assertParseException(invalidCommand, MESSAGE_UNKNOWN_COMMAND);
-//    }
-//
-//    @Test
-//    public void execute_commandExecutionError_throwsCommandException() {
-//        String deleteCommand = "delete 9";
-//        assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-//    }
-//
-//    @Test
-//    public void execute_storageThrowsIoException_throwsCommandException() {
-//        // Setup LogicManager with JsonAddressBookIoExceptionThrowingStub
-//        JsonAddressBookStorage addressBookStorage =
-//                new JsonAddressBookIoExceptionThrowingStub(temporaryFolder.resolve("ioExceptionAddressBook.json"));
-//        JsonUserPrefsStorage userPrefsStorage =
-//                new JsonUserPrefsStorage(temporaryFolder.resolve("ioExceptionUserPrefs.json"));
-//        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
-//        logic = new LogicManager(model, storage);
-//
-//        // Execute add command
-//        String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
-//                + ADDRESS_DESC_AMY;
-//        ModelManager expectedModel = new ModelManager();
-//        String expectedMessage = LogicManager.FILE_OPS_ERROR_MESSAGE + DUMMY_IO_EXCEPTION;
-//        assertCommandFailure(addCommand, CommandException.class, expectedMessage, expectedModel);
-//    }
-//
-//    @Test
-//    public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
-//    }
-//
-//    /**
-//     * Executes the command and confirms that
-//     * - no exceptions are thrown <br>
-//     * - the feedback message is equal to {@code expectedMessage} <br>
-//     * - the internal model manager state is the same as that in {@code expectedModel} <br>
-//     * @see #assertCommandFailure(String, Class, String, Model)
-//     */
-//    private void assertCommandSuccess(String inputCommand, String expectedMessage,
-//            Model expectedModel) throws CommandException, ParseException {
-//        CommandResult result = logic.execute(inputCommand);
-//        assertEquals(expectedMessage, result.getFeedbackToUser());
-//        assertEquals(expectedModel, model);
-//    }
-//
-//    /**
-//     * Executes the command, confirms that a ParseException is thrown and that the result message is correct.
-//     * @see #assertCommandFailure(String, Class, String, Model)
-//     */
-//    private void assertParseException(String inputCommand, String expectedMessage) {
-//        assertCommandFailure(inputCommand, ParseException.class, expectedMessage);
-//    }
-//
-//    /**
-//     * Executes the command, confirms that a CommandException is thrown and that the result message is correct.
-//     * @see #assertCommandFailure(String, Class, String, Model)
-//     */
-//    private void assertCommandException(String inputCommand, String expectedMessage) {
-//        assertCommandFailure(inputCommand, CommandException.class, expectedMessage);
-//    }
-//
-//    /**
-//     * Executes the command, confirms that the exception is thrown and that the result message is correct.
-//     * @see #assertCommandFailure(String, Class, String, Model)
-//     */
-//    private void assertCommandFailure(String inputCommand, Class<? extends Throwable> expectedException,
-//            String expectedMessage) {
-//        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
-//        assertCommandFailure(inputCommand, expectedException, expectedMessage, expectedModel);
-//    }
-//
-//    /**
-//     * Executes the command and confirms that
-//     * - the {@code expectedException} is thrown <br>
-//     * - the resulting error message is equal to {@code expectedMessage} <br>
-//     * - the internal model manager state is the same as that in {@code expectedModel} <br>
-//     * @see #assertCommandSuccess(String, String, Model)
-//     */
-//    private void assertCommandFailure(String inputCommand, Class<? extends Throwable> expectedException,
-//            String expectedMessage, Model expectedModel) {
-//        assertThrows(expectedException, expectedMessage, () -> logic.execute(inputCommand));
-//        assertEquals(expectedModel, model);
-//    }
-//
-//    /**
-//     * A stub class to throw an {@code IOException} when the save method is called.
-//     */
-//    private static class JsonAddressBookIoExceptionThrowingStub extends JsonAddressBookStorage {
-//        private JsonAddressBookIoExceptionThrowingStub(Path filePath) {
-//            super(filePath);
-//        }
-//
-//        @Override
-//        public void saveAddressBook(ReadOnlyAddressBook addressBook, Path filePath) throws IOException {
-//            throw DUMMY_IO_EXCEPTION;
-//        }
-//    }
-//}
+package com.notably.logic;
+
+import static com.notably.testutil.Assert.assertThrows;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.notably.logic.parser.exceptions.ParseException;
+import com.notably.model.Model;
+import com.notably.model.ModelManager;
+import com.notably.model.block.BlockModelImpl;
+import com.notably.model.suggestion.SuggestionModelImpl;
+import com.notably.model.userpref.UserPrefModelImpl;
+import com.notably.model.viewstate.ViewStateModelImpl;
+import com.notably.storage.JsonBlockStorage;
+import com.notably.storage.JsonUserPrefsStorage;
+import com.notably.storage.StorageManager;
+
+public class LogicManagerTest {
+    @TempDir
+    public Path testFolder;
+
+    private StorageManager storageManager;
+    private Model model = new ModelManager(
+            new BlockModelImpl(),
+            new SuggestionModelImpl(),
+            new ViewStateModelImpl(),
+            new UserPrefModelImpl());
+    private Logic logic;
+
+    @BeforeEach
+    public void setUp() throws java.io.IOException {
+        JsonBlockStorage blockStorage = new JsonBlockStorage(getTempFilePath("blocks"));
+        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(getTempFilePath("prefs"));
+        storageManager = new StorageManager(blockStorage, userPrefsStorage);
+        logic = new LogicManager(model, storageManager);
+    }
+
+    private Path getTempFilePath(String fileName) {
+        return testFolder.resolve(fileName);
+    }
+
+    @Test
+    public void execute_invalidCommandFormat_throwsParseException() {
+        String invalidCommand = "uicfhmowqewca";
+        assertThrows(ParseException.class, () -> logic.execute(invalidCommand));
+    }
+
+
+}

--- a/src/test/java/com/notably/logic/LogicManagerTest.java
+++ b/src/test/java/com/notably/logic/LogicManagerTest.java
@@ -1,6 +1,7 @@
 package com.notably.logic;
 
 import static com.notably.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.file.Path;
 
@@ -8,7 +9,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import com.notably.commons.path.AbsolutePath;
 import com.notably.logic.commands.exceptions.CommandException;
+import com.notably.logic.exceptions.EditBlockBodyException;
 import com.notably.logic.parser.exceptions.ParseException;
 import com.notably.model.Model;
 import com.notably.model.ModelManager;
@@ -46,14 +49,36 @@ public class LogicManagerTest {
 
     @Test
     public void execute_invalidCommandFormat_throwsParseException() {
-        String invalidCommand = "uicfhmowqewca";
+        final String invalidCommand = "uicfhmowqewca";
         assertThrows(ParseException.class, () -> logic.execute(invalidCommand));
     }
 
     @Test
     public void execute_invalidCommand_throwsCommandException() {
-        String invalidCommand = "delete /";
+        final String invalidCommand = "delete /";
         assertThrows(CommandException.class, () -> logic.execute(invalidCommand));
     }
 
+    @Test
+    public void editCurrentBlockBody_editRoot_throwEditBlockBodyException() {
+        final String body = "This does not matter";
+
+        assertThrows(EditBlockBodyException.class, () -> logic.editCurrentBlockBody(body));
+    }
+
+    @Test
+    public void editCurrentBlockBody_validCurrentBlock_throwEditBlockBodyException()
+            throws CommandException, ParseException, EditBlockBodyException {
+        final String newCommandText = "new -t iLoveTesting -b really? -o";
+        final String editBody = "This does not matter";
+        logic.execute(newCommandText);
+        logic.editCurrentBlockBody(editBody);
+
+        final AbsolutePath expectedCurrentPath = AbsolutePath.fromString("/iLoveTesting");
+        final String expectedBody = "This does not matter";
+
+
+
+        assertEquals(expectedBody, model.getBlockTree().get(expectedCurrentPath).getBlock().getBody().getText());
+    }
 }


### PR DESCRIPTION
resolves #401 
Due to the change in implementation. 
User will now be able to edit the block body using the MarkdownModel, no longer using the edit command.
This PR:
- [x] provides a method in the `LogicManager` to edit the currentBlockBody.
- [x] LogicMangerTest