### PR TITLE
Update valid path criteria

### DIFF
--- a/src/main/java/com/notably/commons/path/AbsolutePath.java
+++ b/src/main/java/com/notably/commons/path/AbsolutePath.java
@@ -6,14 +6,14 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.notably.commons.path.exceptions.InvalidPathException;
+import com.notably.model.block.Title;
 
 /**
  * Represents the Path to a Block, starting from the Root node.
  */
 public class AbsolutePath implements Path {
     public static final String INVALID_ABSOLUTE_PATH = "Invalid absolute path";
-    public static final String VALIDATION_REGEX = "\\/|(\\/([a-zA-Z0-9]+\\s+)*[a-zA-Z0-9]+)+\\/?";
-    public static final AbsolutePath TO_ROOT_PATH = new AbsolutePath("/");
+    public static final String VALIDATION_REGEX = "\\/|(\\/" + Title.VALIDATION_REGEX + ")+\\/?";
 
     private final List<String> components;
 

--- a/src/main/java/com/notably/commons/path/RelativePath.java
+++ b/src/main/java/com/notably/commons/path/RelativePath.java
@@ -6,14 +6,15 @@ import java.util.List;
 import java.util.Objects;
 
 import com.notably.commons.path.exceptions.InvalidPathException;
+import com.notably.model.block.Title;
 
 /**
  * Represents a path to the block relative to the current directory.
  */
 public class RelativePath implements Path {
     public static final String INVALID_RELATIVE_PATH = "Invalid relative path";
-    public static final String VALIDATION_REGEX = "(\\.|\\..|([a-zA-Z0-9]+\\s+)*[a-zA-Z0-9]+)"
-            + "(\\/(\\.|\\..|([a-zA-Z0-9]+\\s+)*[a-zA-Z0-9]+))*\\/?";
+    public static final String VALIDATION_REGEX =
+            "(\\.|\\..|" + Title.VALIDATION_REGEX + ")(\\/(\\.|\\..|" + Title.VALIDATION_REGEX + "))*\\/?";
 
     private final List<String> components;
 

--- a/src/main/java/com/notably/logic/commands/NewCommand.java
+++ b/src/main/java/com/notably/logic/commands/NewCommand.java
@@ -2,7 +2,6 @@ package com.notably.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import com.notably.commons.path.AbsolutePath;
 import com.notably.logic.commands.exceptions.CommandException;
 import com.notably.model.Model;
 import com.notably.model.block.Block;
@@ -15,12 +14,10 @@ public class NewCommand extends Command {
     public static final String COMMAND_WORD = "new";
     public static final String COMMAND_SHORTHAND = "n";
     private final Block toAdd;
-    private AbsolutePath path;
 
-    public NewCommand(Block block, AbsolutePath path) {
+    public NewCommand(Block block) {
         requireNonNull(block);
         this.toAdd = block;
-        this.path = path;
     }
 
     /**

--- a/src/main/java/com/notably/logic/parser/NewCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/NewCommandParser.java
@@ -42,7 +42,6 @@ public class NewCommandParser implements CommandParser<Command> {
             throw new ParseException(String.format("Invalid Command"));
         }
 
-
         String title = argMultimap.getValue(PREFIX_TITLE).get();
         String body;
         if (!ParserUtil.arePrefixesPresent(argMultimap, PREFIX_BODY)) {
@@ -51,7 +50,6 @@ public class NewCommandParser implements CommandParser<Command> {
             body = argMultimap.getValue(PREFIX_BODY).get();
         }
 
-        AbsolutePath path = ParserUtil.createAbsolutePath(title, notablyModel.getCurrentlyOpenPath());
         Block block;
         try {
             block = new BlockImpl(new Title(title), new Body(body));
@@ -60,15 +58,15 @@ public class NewCommandParser implements CommandParser<Command> {
         }
 
         List<Command> commands = new ArrayList<>();
-        commands.add(new NewCommand(block, path));
+        commands.add(new NewCommand(block));
 
         if (!ParserUtil.arePrefixesPresent(argMultimap, PREFIX_JUMP)) {
             return commands;
         }
 
+        AbsolutePath path = ParserUtil.createAbsolutePath(title, notablyModel.getCurrentlyOpenPath());
         commands.add(new OpenCommand(path));
         return commands;
-
     }
 
 }

--- a/src/main/java/com/notably/model/block/BlockModelImpl.java
+++ b/src/main/java/com/notably/model/block/BlockModelImpl.java
@@ -17,7 +17,7 @@ public class BlockModelImpl implements BlockModel {
 
     public BlockModelImpl() {
         blockTree = new BlockTreeImpl();
-        currentlyOpenPath = new SimpleObjectProperty<AbsolutePath>(AbsolutePath.TO_ROOT_PATH);
+        currentlyOpenPath = new SimpleObjectProperty<AbsolutePath>(AbsolutePath.fromString("/"));
     }
 
     @Override

--- a/src/main/java/com/notably/model/util/SampleDataUtil.java
+++ b/src/main/java/com/notably/model/util/SampleDataUtil.java
@@ -42,7 +42,7 @@ public class SampleDataUtil {
     public static BlockModel getSampleBlockModel() {
         BlockModel sampleBm = new BlockModelImpl();
         BlockTree sampleBt = new BlockTreeImpl();
-        sampleBt.add(AbsolutePath.TO_ROOT_PATH, welcome);
+        sampleBt.add(AbsolutePath.fromString("/"), welcome);
         sampleBt.add(AbsolutePath.fromString("/Welcome"), step1);
         sampleBt.add(AbsolutePath.fromString("/Welcome/"), step2);
         sampleBt.add(AbsolutePath.fromString("/Welcome/"), step3);

--- a/src/main/java/com/notably/storage/JsonSerializableBlockModel.java
+++ b/src/main/java/com/notably/storage/JsonSerializableBlockModel.java
@@ -86,7 +86,7 @@ class JsonSerializableBlockModel {
             return blockModel;
         }
         if (rootChildren.isEmpty()) {
-            blockModel.setCurrentlyOpenBlock(AbsolutePath.TO_ROOT_PATH);
+            blockModel.setCurrentlyOpenBlock(AbsolutePath.fromString("/"));
             return blockModel;
         }
         BlockTreeItem firstChild = rootChildren.get(0);

--- a/src/test/java/com/notably/commons/path/AbsolutePathTest.java
+++ b/src/test/java/com/notably/commons/path/AbsolutePathTest.java
@@ -15,17 +15,18 @@ class AbsolutePathTest {
 
     @Test
     public void fromString_validInputString_generateAbsolutePath() {
-        final AbsolutePath testInput = AbsolutePath.fromString("/CS2103 titty/notes");
+        final AbsolutePath testInput = AbsolutePath.fromString("/CS2103 Happy!/notes/#8.4");
 
         List<String> paths = new ArrayList<>();
-        paths.add("CS2103 titty");
+        paths.add("CS2103 Happy!");
         paths.add("notes");
+        paths.add("#8.4");
 
         assertEquals(paths, testInput.getComponents());
     }
 
     @Test
-    public void fromString_validEmptyString_generateAbsolutePath() {
+    public void fromString_validRootString_generateAbsolutePath() {
         final AbsolutePath testInput = AbsolutePath.fromString("/");
 
         List<String> paths = new ArrayList<>();
@@ -39,14 +40,9 @@ class AbsolutePathTest {
     }
 
     @Test
-    public void fromString_invalidInputString2_exceptionThrown() {
-        assertThrows(InvalidPathException.class, () -> AbsolutePath.fromString("/../CS2103/notes"));
-    }
-
-    @Test
     public void toRelativePath_validInput_correctedPath() {
-        final AbsolutePath inputAbsolutePath = AbsolutePath.fromString("/CS2103/notes/hello");
-        final AbsolutePath inputCurrPath = AbsolutePath.fromString("/CS2103");
+        final AbsolutePath inputAbsolutePath = AbsolutePath.fromString("/&CS2103/notes/hello");
+        final AbsolutePath inputCurrPath = AbsolutePath.fromString("/&CS2103");
 
         final RelativePath expectedOutput = RelativePath.fromString("notes/hello");
 
@@ -55,11 +51,11 @@ class AbsolutePathTest {
 
     @Test
     public void fromRelativePath_validInput_convertedAbsolutePath() {
-        final RelativePath inputRelPath = RelativePath.fromString("../../hello");
-        final AbsolutePath inputCurrPath = AbsolutePath.fromString("/CS2103/filler");
+        final RelativePath inputRelPath = RelativePath.fromString("../../hello??");
+        final AbsolutePath inputCurrPath = AbsolutePath.fromString("/CS.2103/filler");
 
         List<String> expectedPaths = new ArrayList<>();
-        expectedPaths.add("hello");
+        expectedPaths.add("hello??");
 
         assertEquals(expectedPaths, AbsolutePath.fromRelativePath(inputRelPath, inputCurrPath).getComponents());
     }

--- a/src/test/java/com/notably/commons/path/RelativePathTest.java
+++ b/src/test/java/com/notably/commons/path/RelativePathTest.java
@@ -17,31 +17,31 @@ class RelativePathTest {
 
     @Test
     public void fromString_validInputString_generateAbsolutePath() {
-        final RelativePath testInput = RelativePath.fromString("CS2103/notes");
+        final RelativePath testInput = RelativePath.fromString("CS2103/notes~");
         List<String> paths = new ArrayList<>();
         paths.add("CS2103");
-        paths.add("notes");
+        paths.add("notes~");
         assertEquals(paths, testInput.getComponents());
     }
 
     @Test
     public void fromString_invalidInputString_exceptionThrown() {
-        assertThrows(InvalidPathException.class, () -> RelativePath.fromString("/CS2103/notes"));
+        assertThrows(InvalidPathException.class, () -> RelativePath.fromString("/CS2103!/notes"));
     }
 
     @Test
     public void toAbsolutePath_validInput_correctedPath() {
-        final RelativePath inputRelativePath = RelativePath.fromString("CS2103/notes/hello");
+        final RelativePath inputRelativePath = RelativePath.fromString("CS2103/%notes%/hello");
         final AbsolutePath inputCurrPath = AbsolutePath.fromString("/CS2103");
 
-        final AbsolutePath expectedOutput = AbsolutePath.fromString("/CS2103/CS2103/notes/hello");
+        final AbsolutePath expectedOutput = AbsolutePath.fromString("/CS2103/CS2103/%notes%/hello");
 
         assertEquals(expectedOutput, inputRelativePath.toAbsolutePath(inputCurrPath));
     }
 
     @Test
     public void toAbsolutePath_invalidInput_exceptionThrown() {
-        final RelativePath inputRelativePath = RelativePath.fromString("../../notes/hello");
+        final RelativePath inputRelativePath = RelativePath.fromString("../../notes/hello!");
         final AbsolutePath inputCurrPath = AbsolutePath.fromString("/CS2103");
 
         assertThrows(InvalidPathException.class, () -> inputRelativePath.toAbsolutePath(inputCurrPath));
@@ -49,8 +49,8 @@ class RelativePathTest {
 
     @Test
     public void equals_similarPathWithSameCasing_pathAreEqual() {
-        final RelativePath inputRelativePath1 = RelativePath.fromString("CS2103/../CS2103");
-        final RelativePath inputRelativePath2 = RelativePath.fromString("CS2103");
+        final RelativePath inputRelativePath1 = RelativePath.fromString("@CS2103/../@CS2103");
+        final RelativePath inputRelativePath2 = RelativePath.fromString("@CS2103");
 
         assertEquals(inputRelativePath2, inputRelativePath1);
     }

--- a/src/test/java/com/notably/model/block/BlockModelTest.java
+++ b/src/test/java/com/notably/model/block/BlockModelTest.java
@@ -29,7 +29,7 @@ public class BlockModelTest {
             .getRootBlock()
             .getTreeItem()
             .getChildren(), FXCollections.emptyObservableList());
-        assertEquals(blockModel.getCurrentlyOpenPath(), AbsolutePath.TO_ROOT_PATH);
+        assertEquals(blockModel.getCurrentlyOpenPath(), AbsolutePath.fromString("/"));
     }
 
     @Test
@@ -41,7 +41,7 @@ public class BlockModelTest {
 
     @Test
     public void removeBlock_removeRoot() {
-        assertThrows(CannotModifyRootException.class, () -> blockModel.removeBlock(AbsolutePath.TO_ROOT_PATH));
+        assertThrows(CannotModifyRootException.class, () -> blockModel.removeBlock(AbsolutePath.fromString("/")));
     }
 
     @Test
@@ -61,7 +61,7 @@ public class BlockModelTest {
         blockModel.setCurrentlyOpenBlock(AbsolutePath.fromString("/CS3230"));
         blockModel.addBlockToCurrentPath(new BlockImpl(new Title("Week1")));
         blockModel.addBlockToCurrentPath(new BlockImpl(new Title("Week2")));
-        blockModel.setCurrentlyOpenBlock(AbsolutePath.TO_ROOT_PATH);
+        blockModel.setCurrentlyOpenBlock(AbsolutePath.fromString("/"));
         assertTrue(blockModel.hasPath(AbsolutePath.fromString("/CS3230/Week1")));
         assertTrue(blockModel.hasPath(AbsolutePath.fromString("/CS3230/Week2")));
     }
@@ -70,7 +70,7 @@ public class BlockModelTest {
     public void removeBlock_nonRootPath() {
         blockModel.setCurrentlyOpenBlock(AbsolutePath.fromString("/CS3230"));
         blockModel.addBlockToCurrentPath(new BlockImpl(new Title("Week1")));
-        blockModel.setCurrentlyOpenBlock(AbsolutePath.TO_ROOT_PATH);
+        blockModel.setCurrentlyOpenBlock(AbsolutePath.fromString("/"));
         blockModel.removeBlock(AbsolutePath.fromString("/CS3230/Week1"));
     }
 

--- a/src/test/java/com/notably/testutil/TypicalBlockModel.java
+++ b/src/test/java/com/notably/testutil/TypicalBlockModel.java
@@ -14,6 +14,7 @@ import com.notably.model.block.Title;
  * A utility class containing a list of {@code Block} objects to be used in tests.
  */
 public class TypicalBlockModel {
+    public static final AbsolutePath PATH_TO_ROOT = AbsolutePath.fromString("/");
     public static final AbsolutePath PATH_TO_Y2S2 = AbsolutePath.fromString("/Y2S2");
     public static final AbsolutePath PATH_TO_CS2103T = AbsolutePath.fromString("/Y2S2/CS2103T");
     public static final AbsolutePath PATH_TO_CS2103T_LECTURES = AbsolutePath.fromString("/Y2S2/CS2103T/Lecture Notes");
@@ -57,7 +58,7 @@ public class TypicalBlockModel {
     public static BlockModel getTypicalBlockModel() {
         BlockModel blockModel = new BlockModelImpl();
         BlockTree blockTree = new BlockTreeImpl();
-        blockTree.add(AbsolutePath.TO_ROOT_PATH, Y2S2);
+        blockTree.add(PATH_TO_ROOT, Y2S2);
         blockTree.add(PATH_TO_Y2S2, CS2103T);
         blockTree.add(PATH_TO_CS2103T, CS2103T_LECTURES);
         blockTree.add(PATH_TO_CS2103T, CS2103T_TUTORIALS);


### PR DESCRIPTION
Closes #415 

Sorry for the messy PR. It works on a few things, mainly:
1. Update `...Path`'s `VALIDATION_REGEX` to follow that of `Title`.
2. Refactor `NewCommand` and `NewCommandParser` by a bit.
3. Remove `TO_ROOT_PATH` constant. I believe this was created in the past due to `InvalidPathException` being a checked exception, which made calling `AbsolutePath#fromString` very troublesome. Since `InvalidPathException` is no longer a checked exception, let's remove the constant.
4. Update `...PathTest`'s test cases