### PR TITLE
Add default body content for root block

### DIFF
--- a/src/main/java/com/notably/model/block/BlockImpl.java
+++ b/src/main/java/com/notably/model/block/BlockImpl.java
@@ -31,10 +31,10 @@ public class BlockImpl implements Block {
     }
 
     /**
-     * Static method to create and return a root block
+     * Static method to create and return a root block.
      */
     public static Block createRootBlock() {
-        return new BlockImpl(new Title("Root"));
+        return new BlockImpl(new Title("Root"), new Body("Create a new note to get started!"));
     }
 
     @Override

--- a/src/main/java/com/notably/model/block/BlockTreeItemImpl.java
+++ b/src/main/java/com/notably/model/block/BlockTreeItemImpl.java
@@ -27,8 +27,19 @@ public class BlockTreeItemImpl implements BlockTreeItem {
         blockTreeItem = treeItem;
     }
 
+    /**
+     * Static method to create a root {@code BlockTreeItem}
+     */
     public static BlockTreeItem createRootBlockTreeItem() {
-        return new BlockTreeItemImpl(BlockImpl.createRootBlock());
+        Block root = BlockImpl.createRootBlock();
+        TreeItem<Block> rootTreeItem = new TreeItem<Block>(root);
+        rootTreeItem.leafProperty().addListener((observable, oldValue, newValue) -> {
+            Body rootBody = newValue
+                ? new Body("Create a new note to get started!")
+                : new Body("Open a note to get started!");
+            rootTreeItem.setValue(new BlockImpl(rootTreeItem.getValue().getTitle(), rootBody));
+        });
+        return new BlockTreeItemImpl(rootTreeItem);
     }
 
     @Override

--- a/src/test/java/com/notably/model/block/BlockTreeTest.java
+++ b/src/test/java/com/notably/model/block/BlockTreeTest.java
@@ -13,6 +13,7 @@ import com.notably.commons.path.AbsolutePath;
 import com.notably.model.block.exceptions.CannotModifyRootException;
 import com.notably.model.block.exceptions.DuplicateBlockException;
 import com.notably.model.block.exceptions.NoSuchBlockException;
+import com.notably.testutil.TypicalBlockModel;
 
 public class BlockTreeTest {
     private static AbsolutePath toRoot;
@@ -105,5 +106,17 @@ public class BlockTreeTest {
         AbsolutePath editedPath = AbsolutePath.fromString("/CS2103/Week2");
         blockTree.set(toCs2103Week1, editedBlock);
         assertEquals(blockTree.get(editedPath).getBlock(), editedBlock);
+    }
+
+    @Test
+    public void testRootBodyContent() {
+        blockTree = new BlockTreeImpl();
+        assertEquals(blockTree.getRootBlock().getBody().getText(), "Create a new note to get started!");
+
+        blockTree.add(TypicalBlockModel.PATH_TO_ROOT, TypicalBlockModel.Y2S2);
+        assertEquals(blockTree.getRootBlock().getBody().getText(), "Open a note to get started!");
+
+        blockTree.remove(TypicalBlockModel.PATH_TO_Y2S2);
+        assertEquals(blockTree.getRootBlock().getBody().getText(), "Create a new note to get started!");
     }
 }


### PR DESCRIPTION
Closes #426 

If the blockTree is empty (i.e root has no children), show "Create a new note to get started!"
Otherwise, show "Open a note to get started!"