### PR TITLE
CorrectionEngine improvements

### DIFF
--- a/src/main/java/com/notably/logic/commands/DeleteCommand.java
+++ b/src/main/java/com/notably/logic/commands/DeleteCommand.java
@@ -15,7 +15,7 @@ import com.notably.model.block.exceptions.NoSuchBlockException;
  */
 public class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
-    public static final String COMMAND_SHORTHAND = "d";
+
     private Path targetPath;
 
     public DeleteCommand(Path targetPath) {

--- a/src/main/java/com/notably/logic/commands/EditCommand.java
+++ b/src/main/java/com/notably/logic/commands/EditCommand.java
@@ -11,7 +11,6 @@ import com.notably.model.Model;
  */
 public class EditCommand extends Command {
     public static final String COMMAND_WORD = "edit";
-    public static final String COMMAND_SHORTHAND = "e";
 
     private static final String ERROR_ROOT_MODIFICATION = "Editing the root block is forbidden.";
     private static final AbsolutePath ROOT = AbsolutePath.fromString("/");

--- a/src/main/java/com/notably/logic/commands/HelpCommand.java
+++ b/src/main/java/com/notably/logic/commands/HelpCommand.java
@@ -9,7 +9,6 @@ import com.notably.model.Model;
  */
 public class HelpCommand extends Command {
     public static final String COMMAND_WORD = "help";
-    public static final String COMMAND_SHORTHAND = "h";
 
     @Override
     public void execute(Model notablyModel) {

--- a/src/main/java/com/notably/logic/commands/NewCommand.java
+++ b/src/main/java/com/notably/logic/commands/NewCommand.java
@@ -12,7 +12,7 @@ import com.notably.model.block.exceptions.DuplicateBlockException;
  */
 public class NewCommand extends Command {
     public static final String COMMAND_WORD = "new";
-    public static final String COMMAND_SHORTHAND = "n";
+
     private final Block toAdd;
 
     public NewCommand(Block block) {

--- a/src/main/java/com/notably/logic/commands/OpenCommand.java
+++ b/src/main/java/com/notably/logic/commands/OpenCommand.java
@@ -12,7 +12,7 @@ import com.notably.model.block.exceptions.NoSuchBlockException;
  */
 public class OpenCommand extends Command {
     public static final String COMMAND_WORD = "open";
-    public static final String COMMAND_SHORTHAND = "o";
+
     private AbsolutePath path;
 
     public OpenCommand(AbsolutePath path) {

--- a/src/main/java/com/notably/logic/correction/AbsolutePathCorrectionEngine.java
+++ b/src/main/java/com/notably/logic/correction/AbsolutePathCorrectionEngine.java
@@ -153,7 +153,7 @@ public class AbsolutePathCorrectionEngine implements CorrectionEngine<AbsolutePa
             String referenceComponent = referenceComponents.get(i);
 
             if (forwardMatch && i == inputComponents.size() - 1
-                    && inputComponent.length() < referenceComponent.length()) {
+                    && inputComponent.length() <= referenceComponent.length()) {
                 distance += calculateForwardMatchingDistance(inputComponent, referenceComponent);
             } else {
                 distance += editDistanceCalculator.calculateDistance(inputComponent, referenceComponent);

--- a/src/main/java/com/notably/logic/correction/AbsolutePathCorrectionEngine.java
+++ b/src/main/java/com/notably/logic/correction/AbsolutePathCorrectionEngine.java
@@ -20,20 +20,16 @@ import com.notably.model.block.BlockTreeItem;
 public class AbsolutePathCorrectionEngine implements CorrectionEngine<AbsolutePath> {
     private final EditDistanceCalculator editDistanceCalculator;
     private final Model model;
-    private final int distanceThreshold;
-    private final boolean forwardMatch;
+    private final CorrectionEngineParameters parameters;
 
     /**
      * Creates an {@link AbsolutePathCorrectionEngine}.
      *
      * @param model App's model
-     * @param distanceThreshold Edit distance threshold between paths
-     * @param forwardMatch Whether or not to do forward matching. Forward matching refers to the idea
-     * that two paths will be regarded similar if one is an incomplete representation of another.
-     * For example, "/path/to/no" will forward match with "/path/to/note".
+     * @param parameters Parameters for the correction engine
      */
-    public AbsolutePathCorrectionEngine(Model model, int distanceThreshold, boolean forwardMatch) {
-        this(new LevenshteinDistanceCalculator(false), model, distanceThreshold, forwardMatch);
+    public AbsolutePathCorrectionEngine(Model model, CorrectionEngineParameters parameters) {
+        this(new LevenshteinDistanceCalculator(false), model, parameters);
     }
 
     /**
@@ -41,24 +37,17 @@ public class AbsolutePathCorrectionEngine implements CorrectionEngine<AbsolutePa
      *
      * @param editDistanceCalculator Edit distance calculator instance
      * @param model App's model
-     * @param distanceThreshold Edit distance threshold between paths
-     * @param forwardMatch Whether or not to do forward matching. Forward matching refers to the idea
-     * that two paths will be regarded similar if one is an incomplete representation of another.
-     * For example, "/path/to/no" will forward match with "/path/to/note".
+     * @param parameters Parameters for the correction engine
      */
-    public AbsolutePathCorrectionEngine(EditDistanceCalculator editDistanceCalculator,
-            Model model, int distanceThreshold, boolean forwardMatch) {
+    public AbsolutePathCorrectionEngine(EditDistanceCalculator editDistanceCalculator, Model model,
+            CorrectionEngineParameters parameters) {
         Objects.requireNonNull(editDistanceCalculator);
         Objects.requireNonNull(model);
-
-        if (distanceThreshold < 0) {
-            throw new IllegalArgumentException("\"distanceThreshold\" must be greater than 0");
-        }
+        Objects.requireNonNull(parameters);
 
         this.editDistanceCalculator = editDistanceCalculator;
         this.model = model;
-        this.distanceThreshold = distanceThreshold;
-        this.forwardMatch = forwardMatch;
+        this.parameters = parameters;
     }
 
     /**
@@ -89,7 +78,7 @@ public class AbsolutePathCorrectionEngine implements CorrectionEngine<AbsolutePa
             }
         }
 
-        if (closestDistance > distanceThreshold) {
+        if (closestDistance > parameters.getDistanceThreshold()) {
             return new CorrectionResult<>(CorrectionStatus.FAILED);
         }
 
@@ -152,9 +141,11 @@ public class AbsolutePathCorrectionEngine implements CorrectionEngine<AbsolutePa
             String inputComponent = inputComponents.get(i);
             String referenceComponent = referenceComponents.get(i);
 
-            if (forwardMatch && i == inputComponents.size() - 1
+            if (parameters.isForwardMatching()
+                    && i == inputComponents.size() - 1
                     && inputComponent.length() <= referenceComponent.length()) {
-                distance += calculateForwardMatchingDistance(inputComponent, referenceComponent);
+                distance += CorrectionEngineUtil.calculateForwardMatchingDistance(editDistanceCalculator,
+                        inputComponent, referenceComponent, parameters.getForwardMatchingThreshold());
             } else {
                 distance += editDistanceCalculator.calculateDistance(inputComponent, referenceComponent);
             }
@@ -174,29 +165,6 @@ public class AbsolutePathCorrectionEngine implements CorrectionEngine<AbsolutePa
         }
 
         return distance;
-    }
-
-    /**
-     * Calculates the forward matching distance between to path components.
-     *
-     * @param inputComponent Input path component
-     * @param referenceComponent Reference path component
-     * @return Forward matching distance between the two components
-     */
-    private int calculateForwardMatchingDistance(String inputComponent, String referenceComponent) {
-        Objects.requireNonNull(inputComponent);
-        Objects.requireNonNull(referenceComponent);
-
-        int forwardMatchDistance = Integer.MAX_VALUE;
-        for (int stopIndex = 0; stopIndex <= referenceComponent.length(); stopIndex++) {
-            int currentForwardMatchDistance = editDistanceCalculator.calculateDistance(inputComponent,
-                    referenceComponent.substring(0, stopIndex));
-            if (currentForwardMatchDistance < forwardMatchDistance) {
-                forwardMatchDistance = currentForwardMatchDistance;
-            }
-        }
-
-        return forwardMatchDistance;
     }
 }
 

--- a/src/main/java/com/notably/logic/correction/CorrectionEngineParameters.java
+++ b/src/main/java/com/notably/logic/correction/CorrectionEngineParameters.java
@@ -1,0 +1,50 @@
+package com.notably.logic.correction;
+
+/**
+ * Parameters container for the {@link CorrectionEngine} implementation classes.
+ */
+public class CorrectionEngineParameters {
+    private static final int DEFAULT_DISTANCE_THRESHOLD = 2;
+    private static final boolean DEFAULT_FORWARD_MATCHING = false;
+    private static final int DEFAULT_FORWARD_MATCHING_THRESHOLD = 2;
+
+    private int distanceThreshold = DEFAULT_DISTANCE_THRESHOLD;
+    private boolean forwardMatching = DEFAULT_FORWARD_MATCHING;
+    private int forwardMatchingThreshold = DEFAULT_FORWARD_MATCHING_THRESHOLD;
+
+    public int getDistanceThreshold() {
+        return distanceThreshold;
+    }
+
+    public CorrectionEngineParameters setDistanceThreshold(int distanceThreshold) {
+        if (distanceThreshold < 0) {
+            throw new IllegalArgumentException("\"distanceThreshold\" cannot be less than zero");
+        }
+
+        this.distanceThreshold = distanceThreshold;
+        return this;
+    }
+
+    public boolean isForwardMatching() {
+        return forwardMatching;
+    }
+
+    public CorrectionEngineParameters setForwardMatching(boolean forwardMatching) {
+        this.forwardMatching = forwardMatching;
+        return this;
+    }
+
+    public int getForwardMatchingThreshold() {
+        return forwardMatchingThreshold;
+    }
+
+    public CorrectionEngineParameters setForwardMatchingThreshold(int forwardMatchingThreshold) {
+        if (forwardMatchingThreshold < 0) {
+            throw new IllegalArgumentException("\"forwardMatchingThreshold\" cannot be less than zero");
+        }
+
+        this.forwardMatchingThreshold = forwardMatchingThreshold;
+        return this;
+    }
+}
+

--- a/src/main/java/com/notably/logic/correction/CorrectionEngineUtil.java
+++ b/src/main/java/com/notably/logic/correction/CorrectionEngineUtil.java
@@ -31,7 +31,7 @@ public class CorrectionEngineUtil {
         }
 
         if (input.length() < forwardMatchingThreshold) {
-            if (reference.toLowerCase().startsWith(input)) {
+            if (reference.toLowerCase().startsWith(input.toLowerCase())) {
                 return 0;
             }
             return editDistanceCalculator.calculateDistance(input, reference);

--- a/src/main/java/com/notably/logic/correction/CorrectionEngineUtil.java
+++ b/src/main/java/com/notably/logic/correction/CorrectionEngineUtil.java
@@ -1,0 +1,52 @@
+package com.notably.logic.correction;
+
+import java.util.Objects;
+
+import com.notably.logic.correction.distance.EditDistanceCalculator;
+
+/**
+ * Utility class for {@link CorrectionEngine} implementations.
+ */
+public class CorrectionEngineUtil {
+    /**
+     * Calculates the forward matching distance between to {@link String}s.
+     *
+     * @param editDistanceCalculator Edit distance calculator
+     * @param input Input string
+     * @param reference Reference string
+     * @param forwardMatchingThreshold Threshold for forward matching
+     * @return Forward matching distance between the two components
+     */
+    public static int calculateForwardMatchingDistance(EditDistanceCalculator editDistanceCalculator,
+            String input, String reference, int forwardMatchingThreshold) {
+        Objects.requireNonNull(input);
+        Objects.requireNonNull(reference);
+
+        if (input.length() > reference.length()) {
+            throw new IllegalArgumentException("\"input\" cannot be longer than \"reference\"");
+        }
+
+        if (forwardMatchingThreshold < 0) {
+            throw new IllegalArgumentException("\"forwardMatchingThreshold\" cannot be less than zero");
+        }
+
+        if (input.length() < forwardMatchingThreshold) {
+            if (reference.toLowerCase().startsWith(input)) {
+                return 0;
+            }
+            return editDistanceCalculator.calculateDistance(input, reference);
+        }
+
+        int forwardMatchingDistance = Integer.MAX_VALUE;
+        for (int stopIndex = 0; stopIndex <= reference.length(); stopIndex++) {
+            int currentForwardMatchingDistance =
+                    editDistanceCalculator.calculateDistance(input, reference.substring(0, stopIndex));
+            if (currentForwardMatchingDistance < forwardMatchingDistance) {
+                forwardMatchingDistance = currentForwardMatchingDistance;
+            }
+        }
+
+        return forwardMatchingDistance;
+    }
+}
+

--- a/src/main/java/com/notably/logic/parser/NotablyParser.java
+++ b/src/main/java/com/notably/logic/parser/NotablyParser.java
@@ -1,6 +1,7 @@
 package com.notably.logic.parser;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -14,6 +15,7 @@ import com.notably.logic.commands.NewCommand;
 import com.notably.logic.commands.OpenCommand;
 import com.notably.logic.correction.AbsolutePathCorrectionEngine;
 import com.notably.logic.correction.CorrectionEngine;
+import com.notably.logic.correction.CorrectionEngineParameters;
 import com.notably.logic.correction.CorrectionResult;
 import com.notably.logic.correction.CorrectionStatus;
 import com.notably.logic.correction.StringCorrectionEngine;
@@ -25,9 +27,12 @@ import com.notably.model.Model;
  */
 public class NotablyParser {
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
-    private static final List<String> COMMAND_LIST = List.of("new", "edit", "delete", "open", "help", "exit");
-    private static final int CORRECTION_THRESHOLD = 2;
-    private static final boolean USE_PATH_FORWARD_MATCHING = false;
+
+    private static final List<String> COMMAND_LIST = List.of(
+            NewCommand.COMMAND_WORD, EditCommand.COMMAND_WORD,
+            DeleteCommand.COMMAND_WORD, OpenCommand.COMMAND_WORD,
+            HelpCommand.COMMAND_WORD, ExitCommand.COMMAND_WORD);
+
     private static final String ERROR_MESSAGE = "\"%s\" is an invalid command format. "
             + "To see the list of available commands, type: help";
 
@@ -36,10 +41,13 @@ public class NotablyParser {
     private final CorrectionEngine<AbsolutePath> pathCorrectionEngine;
 
     public NotablyParser(Model notablyModel) {
+        Objects.requireNonNull(notablyModel);
+
         this.notablyModel = notablyModel;
-        this.commandCorrectionEngine = new StringCorrectionEngine(COMMAND_LIST, CORRECTION_THRESHOLD);
-        this.pathCorrectionEngine = new AbsolutePathCorrectionEngine(notablyModel, CORRECTION_THRESHOLD,
-                USE_PATH_FORWARD_MATCHING);
+        this.commandCorrectionEngine = new StringCorrectionEngine(COMMAND_LIST,
+                new CorrectionEngineParameters().setForwardMatching(true));
+        this.pathCorrectionEngine = new AbsolutePathCorrectionEngine(notablyModel,
+                new CorrectionEngineParameters().setForwardMatching(false));
     }
     /**
      * Create list of different Commands base on user input.
@@ -54,35 +62,28 @@ public class NotablyParser {
         }
 
         String commandWord = matcher.group("commandWord");
-        if (commandWord.length() > 1) {
-            CorrectionResult<String> correctionResult = commandCorrectionEngine.correct(commandWord);
-            if (correctionResult.getCorrectionStatus() == CorrectionStatus.FAILED) {
-                throw new ParseException(String.format(ERROR_MESSAGE, commandWord));
-            }
-            commandWord = correctionResult.getCorrectedItems().get(0);
+        CorrectionResult<String> correctionResult = commandCorrectionEngine.correct(commandWord);
+        if (correctionResult.getCorrectionStatus() == CorrectionStatus.FAILED) {
+            throw new ParseException(String.format(ERROR_MESSAGE, commandWord));
         }
+        commandWord = correctionResult.getCorrectedItems().get(0);
 
         final String arguments = matcher.group("arguments");
 
         switch (commandWord) {
         case NewCommand.COMMAND_WORD:
-        case NewCommand.COMMAND_SHORTHAND :
             return new NewCommandParser(notablyModel).parse(arguments);
 
         case OpenCommand.COMMAND_WORD:
-        case OpenCommand.COMMAND_SHORTHAND :
             return new OpenCommandParser(notablyModel, pathCorrectionEngine).parse(arguments);
 
         case DeleteCommand.COMMAND_WORD:
-        case DeleteCommand.COMMAND_SHORTHAND:
             return new DeleteCommandParser(notablyModel, pathCorrectionEngine).parse(arguments);
 
         case EditCommand.COMMAND_WORD:
-        case EditCommand.COMMAND_SHORTHAND:
             return List.of(new EditCommand());
 
         case HelpCommand.COMMAND_WORD:
-        case HelpCommand.COMMAND_SHORTHAND:
             return List.of(new HelpCommand());
 
         case ExitCommand.COMMAND_WORD:

--- a/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParser.java
@@ -20,7 +20,6 @@ import com.notably.model.Model;
  */
 public class DeleteSuggestionCommandParser implements SuggestionCommandParser<DeleteSuggestionCommand> {
     public static final String COMMAND_WORD = "delete";
-    public static final String COMMAND_SHORTHAND = "d";
 
     private static final String RESPONSE_MESSAGE = "Delete a note";
     private static final String RESPONSE_MESSAGE_WITH_TITLE = "Delete a note titled \"%s\"";

--- a/src/main/java/com/notably/logic/parser/suggestion/EditSuggestionCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/suggestion/EditSuggestionCommandParser.java
@@ -10,7 +10,6 @@ import com.notably.model.Model;
  */
 public class EditSuggestionCommandParser implements SuggestionCommandParser<SuggestionCommand> {
     public static final String COMMAND_WORD = "edit";
-    public static final String COMMAND_SHORTHAND = "e";
 
     private static final String RESPONSE_MESSAGE = "Edit this note";
 

--- a/src/main/java/com/notably/logic/parser/suggestion/HelpSuggestionCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/suggestion/HelpSuggestionCommandParser.java
@@ -10,7 +10,6 @@ import com.notably.model.Model;
  */
 public class HelpSuggestionCommandParser implements SuggestionCommandParser<SuggestionCommand> {
     public static final String COMMAND_WORD = "help";
-    public static final String COMMAND_SHORTHAND = "h";
 
     private static final String RESPONSE_MESSAGE = "Display a list of available commands";
 

--- a/src/main/java/com/notably/logic/parser/suggestion/NewSuggestionCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/suggestion/NewSuggestionCommandParser.java
@@ -17,7 +17,6 @@ import com.notably.model.block.Title;
  */
 public class NewSuggestionCommandParser implements SuggestionCommandParser<SuggestionCommand> {
     public static final String COMMAND_WORD = "new";
-    public static final String COMMAND_SHORTHAND = "n";
 
     private static final String RESPONSE_MESSAGE = "Create a new note";
     private static final String RESPONSE_MESSAGE_WITH_TITLE = "Create a new note titled \"%s\".";

--- a/src/main/java/com/notably/logic/parser/suggestion/OpenSuggestionCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/suggestion/OpenSuggestionCommandParser.java
@@ -20,7 +20,6 @@ import com.notably.model.Model;
  */
 public class OpenSuggestionCommandParser implements SuggestionCommandParser<OpenSuggestionCommand> {
     public static final String COMMAND_WORD = "open";
-    public static final String COMMAND_SHORTHAND = "o";
 
     private static final String RESPONSE_MESSAGE = "Open a note";
     private static final String RESPONSE_MESSAGE_WITH_TITLE = "Open a note titled \"%s\"";

--- a/src/main/java/com/notably/logic/parser/suggestion/SearchSuggestionCommandParser.java
+++ b/src/main/java/com/notably/logic/parser/suggestion/SearchSuggestionCommandParser.java
@@ -15,7 +15,6 @@ import com.notably.model.Model;
  */
 public class SearchSuggestionCommandParser implements SuggestionCommandParser<SearchSuggestionCommand> {
     public static final String COMMAND_WORD = "search";
-    public static final String COMMAND_SHORTHAND = "s";
 
     private static final String RESPONSE_MESSAGE = "Search through all notes based on keyword";
     private static final String RESPONSE_MESSAGE_WITH_KEYWORD = "Search through all notes based on keyword \"%s\"";

--- a/src/test/java/com/notably/logic/correction/AbsolutePathCorrectionEngineTest.java
+++ b/src/test/java/com/notably/logic/correction/AbsolutePathCorrectionEngineTest.java
@@ -89,15 +89,18 @@ public class AbsolutePathCorrectionEngineTest {
         final int distanceThreshold = 2;
         final AbsolutePathCorrectionEngine correctionEngine = new AbsolutePathCorrectionEngine(
                 model, distanceThreshold, true);
-        final AbsolutePath uncorrectedInput = AbsolutePath.fromString("/Y2S2/cs2103t/tutorials/tutrial");
+        final AbsolutePath uncorrectedInput = AbsolutePath.fromString("/Y2S2/cs2105");
 
-        final List<AbsolutePath> expectedCorrectedItems = List.of(TypicalBlockModel.PATH_TO_CS2103T_TUTORIAL_1,
-                TypicalBlockModel.PATH_TO_CS2103T_TUTORIAL_2);
+        final List<AbsolutePath> expectedCorrectedItems = List.of(TypicalBlockModel.PATH_TO_CS2103T,
+                TypicalBlockModel.PATH_TO_CS2106);
         final CorrectionStatus expectedCorrectionStatus = CorrectionStatus.CORRECTED;
         final CorrectionResult<AbsolutePath> expectedCorrectionResult = new CorrectionResult<>(
                 expectedCorrectionStatus, expectedCorrectedItems);
 
         CorrectionResult<AbsolutePath> correctionResult = correctionEngine.correct(uncorrectedInput);
+
+        System.out.println(correctionResult.getCorrectedItems());
+
         assertEquals(expectedCorrectionResult, correctionResult);
     }
 }

--- a/src/test/java/com/notably/logic/correction/AbsolutePathCorrectionEngineTest.java
+++ b/src/test/java/com/notably/logic/correction/AbsolutePathCorrectionEngineTest.java
@@ -99,10 +99,54 @@ public class AbsolutePathCorrectionEngineTest {
     }
 
     @Test
-    public void correct_withForwardMatchingAndWithinDistanceThreshold_correctionDone() {
+    public void correct_withForwardMatchingAndValidInputAndBelowForwardMatchingThreshold_forwardMatchingDone() {
         final int distanceThreshold = 2;
+        final int forwardMatchingThreshold = 2;
         final AbsolutePathCorrectionEngine correctionEngine = new AbsolutePathCorrectionEngine(model,
-                new CorrectionEngineParameters().setForwardMatching(true).setDistanceThreshold(distanceThreshold));
+                new CorrectionEngineParameters()
+                    .setForwardMatching(true)
+                    .setDistanceThreshold(distanceThreshold)
+                    .setForwardMatchingThreshold(forwardMatchingThreshold));
+        final AbsolutePath uncorrectedInput = AbsolutePath.fromString("/Y");
+
+        final List<AbsolutePath> expectedCorrectedItems = List.of(TypicalBlockModel.PATH_TO_Y2S2);
+        final CorrectionStatus expectedCorrectionStatus = CorrectionStatus.CORRECTED;
+        final CorrectionResult<AbsolutePath> expectedCorrectionResult = new CorrectionResult<>(
+                expectedCorrectionStatus, expectedCorrectedItems);
+
+        CorrectionResult<AbsolutePath> correctionResult = correctionEngine.correct(uncorrectedInput);
+        assertEquals(expectedCorrectionResult, correctionResult);
+    }
+
+    @Test
+    public void correct_withForwardMatchingAndInvalidInputAndBelowForwardMatchingThreshold_noForwardMatching() {
+        final int distanceThreshold = 2;
+        final int forwardMatchingThreshold = 2;
+        final AbsolutePathCorrectionEngine correctionEngine = new AbsolutePathCorrectionEngine(model,
+                new CorrectionEngineParameters()
+                    .setForwardMatching(true)
+                    .setDistanceThreshold(distanceThreshold)
+                    .setForwardMatchingThreshold(forwardMatchingThreshold));
+        final AbsolutePath uncorrectedInput = AbsolutePath.fromString("/Z");
+
+        final List<AbsolutePath> expectedCorrectedItems = List.of(TypicalBlockModel.PATH_TO_ROOT);
+        final CorrectionStatus expectedCorrectionStatus = CorrectionStatus.CORRECTED;
+        final CorrectionResult<AbsolutePath> expectedCorrectionResult = new CorrectionResult<>(
+                expectedCorrectionStatus, expectedCorrectedItems);
+
+        CorrectionResult<AbsolutePath> correctionResult = correctionEngine.correct(uncorrectedInput);
+        assertEquals(expectedCorrectionResult, correctionResult);
+    }
+
+    @Test
+    public void correct_withForwardMatchingAndWithinThresholds_forwardMatchingAndCorrectionDone() {
+        final int distanceThreshold = 2;
+        final int forwardMatchingThreshold = 2;
+        final AbsolutePathCorrectionEngine correctionEngine = new AbsolutePathCorrectionEngine(model,
+                new CorrectionEngineParameters()
+                    .setForwardMatching(true)
+                    .setDistanceThreshold(distanceThreshold)
+                    .setForwardMatchingThreshold(forwardMatchingThreshold));
         final AbsolutePath uncorrectedInput = AbsolutePath.fromString("/Y2S2/cs2105");
 
         final List<AbsolutePath> expectedCorrectedItems = List.of(TypicalBlockModel.PATH_TO_CS2103T,

--- a/src/test/java/com/notably/logic/correction/AbsolutePathCorrectionEngineTest.java
+++ b/src/test/java/com/notably/logic/correction/AbsolutePathCorrectionEngineTest.java
@@ -99,7 +99,7 @@ public class AbsolutePathCorrectionEngineTest {
     }
 
     @Test
-    public void correct_withForwardMatchingAndValidInputAndBelowForwardMatchingThreshold_forwardMatchingDone() {
+    public void correct_withForwardMatchingAndValidPrefixAndBelowForwardMatchingThreshold_forwardMatchingDone() {
         final int distanceThreshold = 2;
         final int forwardMatchingThreshold = 2;
         final AbsolutePathCorrectionEngine correctionEngine = new AbsolutePathCorrectionEngine(model,
@@ -119,7 +119,7 @@ public class AbsolutePathCorrectionEngineTest {
     }
 
     @Test
-    public void correct_withForwardMatchingAndInvalidInputAndBelowForwardMatchingThreshold_noForwardMatching() {
+    public void correct_withForwardMatchingAndInvalidPrefixAndBelowForwardMatchingThreshold_noForwardMatching() {
         final int distanceThreshold = 2;
         final int forwardMatchingThreshold = 2;
         final AbsolutePathCorrectionEngine correctionEngine = new AbsolutePathCorrectionEngine(model,

--- a/src/test/java/com/notably/logic/correction/AbsolutePathCorrectionEngineTest.java
+++ b/src/test/java/com/notably/logic/correction/AbsolutePathCorrectionEngineTest.java
@@ -33,15 +33,15 @@ public class AbsolutePathCorrectionEngineTest {
     public void constructor_constructWithNegativeDistanceThreshold_exceptionThrown() {
         final int negativeDistanceThreshold = -1;
 
-        assertThrows(IllegalArgumentException.class, () ->
-                new AbsolutePathCorrectionEngine(model, negativeDistanceThreshold, true));
+        assertThrows(IllegalArgumentException.class, () -> new AbsolutePathCorrectionEngine(model,
+                    new CorrectionEngineParameters().setDistanceThreshold(negativeDistanceThreshold)));
     }
 
     @Test
     public void correct_noForwardMatchingAndWithinDistanceThreshold_correctionDone() {
         final int distanceThreshold = 2;
-        final AbsolutePathCorrectionEngine correctionEngine = new AbsolutePathCorrectionEngine(
-                model, distanceThreshold, false);
+        final AbsolutePathCorrectionEngine correctionEngine = new AbsolutePathCorrectionEngine(model,
+                new CorrectionEngineParameters().setForwardMatching(false).setDistanceThreshold(distanceThreshold));
         final AbsolutePath uncorrectedInput = AbsolutePath.fromString("/y2s2/Cs2103t/Tutorials/tutorial");
 
         final List<AbsolutePath> expectedCorrectedItems = List.of(TypicalBlockModel.PATH_TO_CS2103T_TUTORIAL_1,
@@ -57,8 +57,8 @@ public class AbsolutePathCorrectionEngineTest {
     @Test
     public void correct_noForwardMatchingAndExceedDistanceThreshold_correctionFailed() {
         final int distanceThreshold = 1;
-        final AbsolutePathCorrectionEngine correctionEngine = new AbsolutePathCorrectionEngine(
-                model, distanceThreshold, false);
+        final AbsolutePathCorrectionEngine correctionEngine = new AbsolutePathCorrectionEngine(model,
+                new CorrectionEngineParameters().setForwardMatching(false).setDistanceThreshold(distanceThreshold));
         final AbsolutePath uncorrectedInput = AbsolutePath.fromString("/Y2s2/Cs");
 
         final CorrectionStatus expectedCorrectedStatus = CorrectionStatus.FAILED;
@@ -71,8 +71,8 @@ public class AbsolutePathCorrectionEngineTest {
     @Test
     public void correct_noForwardMatchingAndExactMatch_noCorrection() {
         final int distanceThreshold = 1;
-        final AbsolutePathCorrectionEngine correctionEngine = new AbsolutePathCorrectionEngine(
-                model, distanceThreshold, false);
+        final AbsolutePathCorrectionEngine correctionEngine = new AbsolutePathCorrectionEngine(model,
+                new CorrectionEngineParameters().setForwardMatching(false).setDistanceThreshold(distanceThreshold));
         final AbsolutePath uncorrectedInput = AbsolutePath.fromString("/Y2s2/cs2106");
 
         final List<AbsolutePath> expectedCorrectedItems = List.of(TypicalBlockModel.PATH_TO_CS2106);
@@ -87,8 +87,8 @@ public class AbsolutePathCorrectionEngineTest {
     @Test
     public void correct_forwardMatchingAndWithinThreshold_correctionDone() {
         final int distanceThreshold = 2;
-        final AbsolutePathCorrectionEngine correctionEngine = new AbsolutePathCorrectionEngine(
-                model, distanceThreshold, true);
+        final AbsolutePathCorrectionEngine correctionEngine = new AbsolutePathCorrectionEngine(model,
+                new CorrectionEngineParameters().setForwardMatching(true).setDistanceThreshold(distanceThreshold));
         final AbsolutePath uncorrectedInput = AbsolutePath.fromString("/Y2S2/cs2105");
 
         final List<AbsolutePath> expectedCorrectedItems = List.of(TypicalBlockModel.PATH_TO_CS2103T,

--- a/src/test/java/com/notably/logic/correction/AbsolutePathCorrectionEngineTest.java
+++ b/src/test/java/com/notably/logic/correction/AbsolutePathCorrectionEngineTest.java
@@ -30,11 +30,25 @@ public class AbsolutePathCorrectionEngineTest {
     }
 
     @Test
-    public void constructor_constructWithNegativeDistanceThreshold_exceptionThrown() {
+    public void constructor_nullModel_exceptionThrown() {
+        assertThrows(NullPointerException.class, () ->
+                new AbsolutePathCorrectionEngine(null, new CorrectionEngineParameters()));
+    }
+
+    @Test
+    public void constructor_negativeDistanceThreshold_exceptionThrown() {
         final int negativeDistanceThreshold = -1;
 
         assertThrows(IllegalArgumentException.class, () -> new AbsolutePathCorrectionEngine(model,
-                    new CorrectionEngineParameters().setDistanceThreshold(negativeDistanceThreshold)));
+                new CorrectionEngineParameters().setDistanceThreshold(negativeDistanceThreshold)));
+    }
+
+    @Test
+    public void constructor_negativeForwardMatchingThreshold_exceptionThrown() {
+        final int negativeForwardMatchingThreshold = -1;
+
+        assertThrows(IllegalArgumentException.class, () -> new AbsolutePathCorrectionEngine(model,
+                new CorrectionEngineParameters().setForwardMatchingThreshold(negativeForwardMatchingThreshold)));
     }
 
     @Test
@@ -85,7 +99,7 @@ public class AbsolutePathCorrectionEngineTest {
     }
 
     @Test
-    public void correct_forwardMatchingAndWithinThreshold_correctionDone() {
+    public void correct_withForwardMatchingAndWithinDistanceThreshold_correctionDone() {
         final int distanceThreshold = 2;
         final AbsolutePathCorrectionEngine correctionEngine = new AbsolutePathCorrectionEngine(model,
                 new CorrectionEngineParameters().setForwardMatching(true).setDistanceThreshold(distanceThreshold));
@@ -98,9 +112,6 @@ public class AbsolutePathCorrectionEngineTest {
                 expectedCorrectionStatus, expectedCorrectedItems);
 
         CorrectionResult<AbsolutePath> correctionResult = correctionEngine.correct(uncorrectedInput);
-
-        System.out.println(correctionResult.getCorrectedItems());
-
         assertEquals(expectedCorrectionResult, correctionResult);
     }
 }

--- a/src/test/java/com/notably/logic/correction/StringCorrectionEngineTest.java
+++ b/src/test/java/com/notably/logic/correction/StringCorrectionEngineTest.java
@@ -87,10 +87,53 @@ public class StringCorrectionEngineTest {
     }
 
     @Test
-    public void correct_withForwardMatchingAndWithinDistanceThreshold_correctionDone() {
+    public void correct_withForwardMatchingAndValidInputAndBelowForwardMatchingThreshold_forwardMatchingDone() {
         final int distanceThreshold = 2;
+        final int forwardMatchingThreshold = 2;
         final StringCorrectionEngine correctionEngine = new StringCorrectionEngine(OPTIONS,
-                new CorrectionEngineParameters().setForwardMatching(true).setDistanceThreshold(distanceThreshold));
+                new CorrectionEngineParameters()
+                    .setForwardMatching(true)
+                    .setDistanceThreshold(distanceThreshold)
+                    .setForwardMatchingThreshold(forwardMatchingThreshold));
+        final String uncorrectedInput = "D";
+
+        final List<String> expectedCorrectedItems = List.of("delete");
+        final CorrectionStatus expectedCorrectionStatus = CorrectionStatus.CORRECTED;
+        final CorrectionResult<String> expectedCorrectionResult = new CorrectionResult<>(
+                expectedCorrectionStatus, expectedCorrectedItems);
+
+        CorrectionResult<String> correctionResult = correctionEngine.correct(uncorrectedInput);
+        assertEquals(expectedCorrectionResult, correctionResult);
+    }
+
+    @Test
+    public void correct_withForwardMatchingAndInvalidInputAndBelowForwardMatchingThreshold_noForwardMatching() {
+        final int distanceThreshold = 2;
+        final int forwardMatchingThreshold = 2;
+        final StringCorrectionEngine correctionEngine = new StringCorrectionEngine(OPTIONS,
+                new CorrectionEngineParameters()
+                    .setForwardMatching(true)
+                    .setDistanceThreshold(distanceThreshold)
+                    .setForwardMatchingThreshold(forwardMatchingThreshold));
+        final String uncorrectedInput = "F";
+
+        final CorrectionStatus expectedCorrectionStatus = CorrectionStatus.FAILED;
+        final CorrectionResult<String> expectedCorrectionResult = new CorrectionResult<>(
+                expectedCorrectionStatus);
+
+        CorrectionResult<String> correctionResult = correctionEngine.correct(uncorrectedInput);
+        assertEquals(expectedCorrectionResult, correctionResult);
+    }
+
+    @Test
+    public void correct_withForwardMatchingAndWithinThresholds_forwardMatchingAndCorrectionDone() {
+        final int distanceThreshold = 2;
+        final int forwardMatchingThreshold = 2;
+        final StringCorrectionEngine correctionEngine = new StringCorrectionEngine(OPTIONS,
+                new CorrectionEngineParameters()
+                    .setForwardMatching(true)
+                    .setDistanceThreshold(distanceThreshold)
+                    .setForwardMatchingThreshold(forwardMatchingThreshold));
         final String uncorrectedInput = "DL";
 
         final List<String> expectedCorrectedItems = List.of("delete");
@@ -101,5 +144,6 @@ public class StringCorrectionEngineTest {
         CorrectionResult<String> correctionResult = correctionEngine.correct(uncorrectedInput);
         assertEquals(expectedCorrectionResult, correctionResult);
     }
+
 }
 

--- a/src/test/java/com/notably/logic/correction/StringCorrectionEngineTest.java
+++ b/src/test/java/com/notably/logic/correction/StringCorrectionEngineTest.java
@@ -15,22 +15,23 @@ public class StringCorrectionEngineTest {
         final List<String> emptyOptions = List.of();
         final int distanceThreshold = 5;
 
-        assertThrows(IllegalArgumentException.class, () ->
-                new StringCorrectionEngine(emptyOptions, distanceThreshold));
+        assertThrows(IllegalArgumentException.class, () -> new StringCorrectionEngine(emptyOptions,
+                    new CorrectionEngineParameters().setDistanceThreshold(distanceThreshold)));
     }
 
     @Test
     public void correct_constructWithNegativeDistanceThreshold_exceptionThrown() {
         final int negativeDistanceThreshold = -1;
 
-        assertThrows(IllegalArgumentException.class, () ->
-                new StringCorrectionEngine(OPTIONS, negativeDistanceThreshold));
+        assertThrows(IllegalArgumentException.class, () -> new StringCorrectionEngine(OPTIONS,
+                    new CorrectionEngineParameters().setDistanceThreshold(negativeDistanceThreshold)));
     }
 
     @Test
     public void correct_withinDistanceThreshold_correctionDone() {
         final int distanceThreshold = 2;
-        final StringCorrectionEngine correctionEngine = new StringCorrectionEngine(OPTIONS, distanceThreshold);
+        final StringCorrectionEngine correctionEngine = new StringCorrectionEngine(OPTIONS,
+                new CorrectionEngineParameters().setDistanceThreshold(distanceThreshold));
         final String uncorrectedInput = "NRW";
 
         final List<String> expectedCorrectedItems = List.of("new");
@@ -45,7 +46,8 @@ public class StringCorrectionEngineTest {
     @Test
     public void correct_exceedDistanceThreshold_correctionFailed() {
         final int distanceThreshold = 1;
-        final StringCorrectionEngine correctionEngine = new StringCorrectionEngine(OPTIONS, distanceThreshold);
+        final StringCorrectionEngine correctionEngine = new StringCorrectionEngine(OPTIONS,
+                new CorrectionEngineParameters().setDistanceThreshold(distanceThreshold));
         final String uncorrectedInput = "OPne";
 
         final CorrectionStatus expectedCorrectedStatus = CorrectionStatus.FAILED;
@@ -58,7 +60,8 @@ public class StringCorrectionEngineTest {
     @Test
     public void correct_exactlyMatchOption_noCorrection() {
         final int distanceThreshold = 1;
-        final StringCorrectionEngine correctionEngine = new StringCorrectionEngine(OPTIONS, distanceThreshold);
+        final StringCorrectionEngine correctionEngine = new StringCorrectionEngine(OPTIONS,
+                new CorrectionEngineParameters().setDistanceThreshold(distanceThreshold));
         final String uncorrectedInput = "hELP";
 
         final List<String> expectedCorrectedItems = List.of("help");

--- a/src/test/java/com/notably/logic/correction/StringCorrectionEngineTest.java
+++ b/src/test/java/com/notably/logic/correction/StringCorrectionEngineTest.java
@@ -87,7 +87,7 @@ public class StringCorrectionEngineTest {
     }
 
     @Test
-    public void correct_withForwardMatchingAndValidInputAndBelowForwardMatchingThreshold_forwardMatchingDone() {
+    public void correct_withForwardMatchingAndValidPrefixAndBelowForwardMatchingThreshold_forwardMatchingDone() {
         final int distanceThreshold = 2;
         final int forwardMatchingThreshold = 2;
         final StringCorrectionEngine correctionEngine = new StringCorrectionEngine(OPTIONS,
@@ -107,7 +107,7 @@ public class StringCorrectionEngineTest {
     }
 
     @Test
-    public void correct_withForwardMatchingAndInvalidInputAndBelowForwardMatchingThreshold_noForwardMatching() {
+    public void correct_withForwardMatchingAndInvalidPrefixAndBelowForwardMatchingThreshold_noForwardMatching() {
         final int distanceThreshold = 2;
         final int forwardMatchingThreshold = 2;
         final StringCorrectionEngine correctionEngine = new StringCorrectionEngine(OPTIONS,

--- a/src/test/java/com/notably/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/com/notably/logic/parser/DeleteCommandParserTest.java
@@ -12,6 +12,7 @@ import com.notably.logic.commands.DeleteCommand;
 import com.notably.logic.commands.exceptions.CommandException;
 import com.notably.logic.correction.AbsolutePathCorrectionEngine;
 import com.notably.logic.correction.CorrectionEngine;
+import com.notably.logic.correction.CorrectionEngineParameters;
 import com.notably.logic.parser.exceptions.ParseException;
 import com.notably.model.Model;
 import com.notably.model.ModelManager;
@@ -23,8 +24,6 @@ import com.notably.model.viewstate.ViewStateModelImpl;
 import com.notably.testutil.TypicalBlockModel;
 
 class DeleteCommandParserTest {
-    private static final int CORRECTION_THRESHOLD = 2;
-    private static final boolean USE_FORWARD_MATCHING = false;
     private static Model model;
     private static DeleteCommandParser deleteCommandParser;
 
@@ -36,7 +35,7 @@ class DeleteCommandParserTest {
         ViewStateModel viewStateModel = new ViewStateModelImpl();
         model = new ModelManager(blockModel, suggestionModel, viewStateModel);
         CorrectionEngine<AbsolutePath> pathCorrectionEngine = new AbsolutePathCorrectionEngine(model,
-                CORRECTION_THRESHOLD, USE_FORWARD_MATCHING);
+                new CorrectionEngineParameters().setForwardMatching(false).setDistanceThreshold(2));
         deleteCommandParser = new DeleteCommandParser(model, pathCorrectionEngine);
 
     }

--- a/src/test/java/com/notably/logic/parser/OpenCommandParserTest.java
+++ b/src/test/java/com/notably/logic/parser/OpenCommandParserTest.java
@@ -11,6 +11,7 @@ import com.notably.logic.commands.OpenCommand;
 import com.notably.logic.commands.exceptions.CommandException;
 import com.notably.logic.correction.AbsolutePathCorrectionEngine;
 import com.notably.logic.correction.CorrectionEngine;
+import com.notably.logic.correction.CorrectionEngineParameters;
 import com.notably.logic.parser.exceptions.ParseException;
 import com.notably.model.Model;
 import com.notably.model.ModelManager;
@@ -22,14 +23,8 @@ import com.notably.model.viewstate.ViewStateModelImpl;
 import com.notably.testutil.TypicalBlockModel;
 
 class OpenCommandParserTest {
-    private static final int CORRECTION_THRESHOLD = 2;
-    private static final boolean USE_FORWARD_MATCHING = false;
-    private static AbsolutePath toBlock;
-    private static AbsolutePath toAnother;
-    private static AbsolutePath toAnotherBlock;
     private static Model model;
     private static OpenCommandParser openCommandParser;
-    private static NotablyParser parser;
 
     @BeforeEach
     public void setUp() {
@@ -39,10 +34,8 @@ class OpenCommandParserTest {
         ViewStateModel viewStateModel = new ViewStateModelImpl();
         model = new ModelManager(blockModel, suggestionModel, viewStateModel);
         CorrectionEngine<AbsolutePath> pathCorrectionEngine = new AbsolutePathCorrectionEngine(model,
-                CORRECTION_THRESHOLD, USE_FORWARD_MATCHING);
+                new CorrectionEngineParameters().setForwardMatching(false).setDistanceThreshold(2));
         openCommandParser = new OpenCommandParser(model, pathCorrectionEngine);
-
-        parser = new NotablyParser(model);
     }
 
     @Test

--- a/src/test/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParserTest.java
+++ b/src/test/java/com/notably/logic/parser/suggestion/DeleteSuggestionCommandParserTest.java
@@ -15,6 +15,7 @@ import com.notably.commons.path.AbsolutePath;
 import com.notably.logic.commands.suggestion.SuggestionCommand;
 import com.notably.logic.correction.AbsolutePathCorrectionEngine;
 import com.notably.logic.correction.CorrectionEngine;
+import com.notably.logic.correction.CorrectionEngineParameters;
 import com.notably.logic.suggestion.SuggestionTestUtil;
 import com.notably.model.Model;
 import com.notably.model.suggestion.SuggestionItem;
@@ -28,8 +29,6 @@ public class DeleteSuggestionCommandParserTest {
     private static final String RESPONSE_MESSAGE = "Delete a note";
     private static final String RESPONSE_MESSAGE_WITH_TITLE = "Delete a note titled \"%s\"";
     private static final String ERROR_MESSAGE_CANNOT_DELETE_NOTE = "Cannot delete \"%s\" as it is an invalid path";
-    private static final int CORRECTION_THRESHOLD = 2;
-    private static final boolean USE_FORWARD_MATCHING = true;
 
     @BeforeAll
     public static void setUp() {
@@ -38,7 +37,7 @@ public class DeleteSuggestionCommandParserTest {
         stringRelativePathToCs2103t = SuggestionTestUtil.getStringRelativePathToCs2103t();
 
         CorrectionEngine<AbsolutePath> pathCorrectionEngine = new AbsolutePathCorrectionEngine(model,
-                CORRECTION_THRESHOLD, USE_FORWARD_MATCHING);
+                new CorrectionEngineParameters().setForwardMatching(true));
         deleteSuggestionCommandParser = new DeleteSuggestionCommandParser(model, pathCorrectionEngine);
     }
 
@@ -163,7 +162,7 @@ public class DeleteSuggestionCommandParserTest {
     @Test
     public void parse_correctedCmdcorrectedAbsolutePathWithPrefix_returnsDeleteSuggestionCommand() {
         String userInputWithoutPath = "dele " + PREFIX_TITLE + " ";
-        String path = "/Y2S2/CS2104";
+        String path = "/Y2S2/CS2104T";
         String userInput = userInputWithoutPath + path;
         String arg = " " + PREFIX_TITLE + " " + path;
 
@@ -187,7 +186,7 @@ public class DeleteSuggestionCommandParserTest {
     @Test
     public void parse_correctCmdcorrectedAbsolutePathWithoutPrefix_returnsDeleteSuggestionCommand() {
         String userInputWithoutPath = DeleteSuggestionCommandParser.COMMAND_WORD + " ";
-        String path = "/Y2S2/CS2104";
+        String path = "/Y2S2/CS2104T";
         String userInput = userInputWithoutPath + path;
         String arg = " " + path;
 
@@ -211,7 +210,7 @@ public class DeleteSuggestionCommandParserTest {
     @Test
     public void parse_correctedCmdcorrectedRelativePathWithPrefix_returnsDeleteSuggestionCommand() {
         String userInputWithoutPath = "dele " + PREFIX_TITLE + " ";
-        String path = "CS2104";
+        String path = "CS2104T";
         String userInput = userInputWithoutPath + path;
         String arg = " " + PREFIX_TITLE + " " + path;
 
@@ -235,7 +234,7 @@ public class DeleteSuggestionCommandParserTest {
     @Test
     public void parse_correctCmdcorrectedRelativePathWithoutPrefix_returnsDeleteSuggestionCommand() {
         String userInputWithoutPath = DeleteSuggestionCommandParser.COMMAND_WORD + " ";
-        String path = "CS2104";
+        String path = "CS2104T";
         String userInput = userInputWithoutPath + path;
         String arg = " " + path;
 

--- a/src/test/java/com/notably/logic/parser/suggestion/OpenSuggestionCommandParserTest.java
+++ b/src/test/java/com/notably/logic/parser/suggestion/OpenSuggestionCommandParserTest.java
@@ -15,6 +15,7 @@ import com.notably.commons.path.AbsolutePath;
 import com.notably.logic.commands.suggestion.SuggestionCommand;
 import com.notably.logic.correction.AbsolutePathCorrectionEngine;
 import com.notably.logic.correction.CorrectionEngine;
+import com.notably.logic.correction.CorrectionEngineParameters;
 import com.notably.logic.suggestion.SuggestionTestUtil;
 import com.notably.model.Model;
 import com.notably.model.suggestion.SuggestionItem;
@@ -28,8 +29,6 @@ public class OpenSuggestionCommandParserTest {
     private static final String RESPONSE_MESSAGE = "Open a note";
     private static final String RESPONSE_MESSAGE_WITH_TITLE = "Open a note titled \"%s\"";
     private static final String ERROR_MESSAGE_CANNOT_OPEN_NOTE = "Cannot open \"%s\" as it is an invalid path";
-    private static final int CORRECTION_THRESHOLD = 2;
-    private static final boolean USE_FORWARD_MATCHING = true;
 
     @BeforeAll
     public static void setUp() {
@@ -38,7 +37,7 @@ public class OpenSuggestionCommandParserTest {
         stringRelativePathToCs2103t = SuggestionTestUtil.getStringRelativePathToCs2103t();
 
         CorrectionEngine<AbsolutePath> pathCorrectionEngine = new AbsolutePathCorrectionEngine(model,
-                CORRECTION_THRESHOLD, USE_FORWARD_MATCHING);
+                new CorrectionEngineParameters().setForwardMatching(true));
         openSuggestionCommandParser = new OpenSuggestionCommandParser(model, pathCorrectionEngine);
     }
 
@@ -163,7 +162,7 @@ public class OpenSuggestionCommandParserTest {
     @Test
     public void parse_correctedCmdcorrectedAbsolutePathWithPrefix_returnsOpenSuggestionCommand() {
         String userInputWithoutPath = "op " + PREFIX_TITLE + " ";
-        String path = "/Y2S2/CS2104";
+        String path = "/Y2S2/CS2104T";
         String userInput = userInputWithoutPath + path;
         String arg = " " + PREFIX_TITLE + " " + path;
 
@@ -187,7 +186,7 @@ public class OpenSuggestionCommandParserTest {
     @Test
     public void parse_correctCmdcorrectedAbsolutePathWithoutPrefix_returnsOpenSuggestionCommand() {
         String userInputWithoutPath = OpenSuggestionCommandParser.COMMAND_WORD + " ";
-        String path = "/Y2S2/CS2104";
+        String path = "/Y2S2/CS2104T";
         String userInput = userInputWithoutPath + path;
         String arg = " " + path;
 
@@ -211,7 +210,7 @@ public class OpenSuggestionCommandParserTest {
     @Test
     public void parse_correctedCmdcorrectedRelativePathWithPrefix_returnsOpenSuggestionCommand() {
         String userInputWithoutPath = "op " + PREFIX_TITLE + " ";
-        String path = "CS2104";
+        String path = "CS2104T";
         String userInput = userInputWithoutPath + path;
         String arg = " " + PREFIX_TITLE + " " + path;
 
@@ -235,7 +234,7 @@ public class OpenSuggestionCommandParserTest {
     @Test
     public void parse_correctCmdcorrectedRelativePathWithoutPrefix_returnsOpenSuggestionCommand() {
         String userInputWithoutPath = OpenSuggestionCommandParser.COMMAND_WORD + " ";
-        String path = "CS2104";
+        String path = "CS2104T";
         String userInput = userInputWithoutPath + path;
         String arg = " " + path;
 

--- a/src/test/java/com/notably/logic/suggestion/SuggestionEngineImplTest.java
+++ b/src/test/java/com/notably/logic/suggestion/SuggestionEngineImplTest.java
@@ -51,17 +51,6 @@ public class SuggestionEngineImplTest {
     }
 
     @Test
-    public void suggest_inputLengthTooShort_noResponseTextDisplayed() {
-        suggestionEngine.suggest("");
-        assertTrue(model.getSuggestions().isEmpty());
-        assertTrue(model.responseTextProperty().getValue().isEmpty());
-
-        suggestionEngine.suggest("o");
-        assertTrue(model.getSuggestions().isEmpty());
-        assertTrue(model.responseTextProperty().getValue().isEmpty());
-    }
-
-    @Test
     public void suggest_correctedDeleteCommand_generatesSuggestions() {
         String userInputWithoutPath = "dele ";
         String path = toCs2103t.getStringRepresentation();

--- a/src/test/java/com/notably/logic/suggestion/SuggestionEngineImplTest.java
+++ b/src/test/java/com/notably/logic/suggestion/SuggestionEngineImplTest.java
@@ -2,7 +2,6 @@ package com.notably.logic.suggestion;
 
 import static com.notably.logic.parser.CliSyntax.PREFIX_TITLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
**Apologies for not splitting this PR into smaller PRs, their changes are very related to one another**

This PR works on:
- [x] Make `StringCorrectionEngine` support forward matching (Solves #449).
This is needed to support better suggestion and parsing experience. Because of this change, two other things are affected:
  - Shorthand commands can be removed. `StringCorrectionEngine` can do the matching by itself. That is, if we type `n`, `StringCorrectionEngine` can now match this to a `new` command.
  - We can now type `del` and `StringCorrectionEngine` will correct this to a `delete` command. Previously, without forward matching in `StringCorrectionEngine`, this is not possible.
- [x] Improve forward matching rules.

  We introduce one more parameter, namely `forwardMatchingThreshold`. This threshold defines the minimum number of characters needed in the input before forward matching takes place alongside correction. Below it, forward matching will still take place, but without correction.

  E.g.: Suppose we set `forwardMatching` to `true` and `forwardMatchingThreshold` to 2. `d` will correct to `delete`, but `b` won't correct to delete due to it having a length below `forwardMatchingThreshold` (`"b".length() == 1` while `forwardMatchingThreshold == 2`). However, `bel` with correct to `delete`, as its length is now above the `forwardMatchingThreshold` (`"b".length() == 3` while `forwardMatchingThreshold == 2`).
- [x] Update dependents of `StringCorrectionEngine` and `AbsolutePathCorrectionEngine` to use these new changes.
- [x] Add more comprehensive test cases for `StringCorrectionEngine` and `AbsolutePathCorrectionEngine`
